### PR TITLE
Improve OBS API

### DIFF
--- a/obs/obs-api.yaml
+++ b/obs/obs-api.yaml
@@ -81,16 +81,11 @@ paths:
       description: Use this endpoint to retrieve a file by its ID.
       operationId: getFile
       parameters:
-        - name: id
-          in: path
-          description: The ID of the file you would like to retrieve
-          required: true
-          schema:
-            type: string
-            format: uuid
+        - $ref: '#/components/parameters/ResourceId'
         - name: token
           in: query
           description: Your JWT token or API key
+          required: true
           schema:
             type: string
       responses:
@@ -119,6 +114,7 @@ paths:
         - name: token
           in: query
           description: Your JWT token or API key
+          required: true
           schema:
             type: string
       responses:

--- a/obs/obs-api.yaml
+++ b/obs/obs-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 
 info:
-  title: Inperium Obs API
+  title: Inperium OBS API
   description: |
     RESTful API to store and retrieve documents.
   version: 1.0.0-SNAPSHOT
@@ -17,10 +17,10 @@ security:
 tags:
   - name: Files
     description: |
-      Inperium Obs stores files. In most cases, files are attached to product entities but some files are stored independently (e.g., avatar images).
+      Inperium OBS stores files. In most cases, files are attached to product entities but some files are stored independently (e.g., avatar images).
   - name: FileTypes
     description: |
-      Inperium Obs enables users to upload files such as pdfs, png, etc. The FileTypes list all supported file extensions.
+      Inperium OBS enables users to upload files such as pdfs, png, etc. The FileTypes list all supported file extensions.
 
 paths:
   /health:
@@ -45,7 +45,7 @@ paths:
       tags:
         - Files
       summary: Upload file
-      description: Use this endpoint to upload a new file to Inperium Obs. For example, a contract or image.
+      description: Use this endpoint to upload a new file to Inperium OBS.
       operationId: uploadFile
       requestBody:
         content:
@@ -72,6 +72,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResponseError'
+
   /files/{id}:
     get:
       tags:
@@ -90,7 +91,6 @@ paths:
         - name: token
           in: query
           description: Your JWT token or API key
-          required: true
           schema:
             type: string
       responses:
@@ -99,31 +99,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DataFile'
+                $ref: '#/components/schemas/StoredFile'
         default:
           description: Bad request, security violation, or internal server error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResponseError'
-  /files/{id}/content:
+
+  /blob/files/{id}:
     get:
       tags:
         - Files
-      summary: Retrieve the contents of file
-      description: Use this endpoint to see the file.
-      operationId: getFileContent
+      summary: Retrieve a file as a blob
+      description: Use this endpoint to retrieve a file as a blob
+      operationId: getFileBlob
       parameters:
         - $ref: '#/components/parameters/ResourceId'
         - name: token
           in: query
           description: Your JWT token or API key
-          required: true
           schema:
             type: string
       responses:
         200:
-          description: The file contents have been retrieved
+          description: The file has been retrieved
           content:
             application/json:
               schema:
@@ -140,12 +140,14 @@ components:
     BearerAuth:
       type: http
       scheme: bearer
+
     ApiKeyAuth:
       type: apiKey
       in: header
       name: X-API-KEY
+
   schemas:
-    DataFile:
+    StoredFile:
       type: object
       properties:
         id:
@@ -167,7 +169,8 @@ components:
         updatedAt:
           type: integer
           format: int64
-      description: A file stored in CRM
+      description: A file stored in the OBS service.
+
     ErrorModel:
       required:
         - code
@@ -191,9 +194,11 @@ components:
           type: string
           description: Comma separated list of fields, which caused the error condition
       description: An individual error
+
     Id:
       type: string
       format: uuid
+
     ResponseError:
       type: object
       properties:
@@ -201,16 +206,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ErrorModel'
+
   responses:
     EmptyResponse:
       description: An empty response that is used for OK non-returning operations
       content: {}
+
     ErrorResponse:
       description: Bad request, security violation, or internal server error
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ResponseError'
+
   parameters:
     ResourceId:
       name: id
@@ -219,6 +227,3 @@ components:
       schema:
         type: string
         format: uuid
-
-
-


### PR DESCRIPTION
This PR improves the API of the OBS server by making it easier for the frontend to retrieve files as BLOBS. It now checks if the token is in the header and only if not it falls back to the token query param. This allows for easy access to protected files within the Inperium UIs but also gives enough flexibility for API customers to use the JWT tokens or API Keys to retrieve static content outside of our apps.