### PR TITLE
Feature/IBA-70

### DIFF
--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -1736,6 +1736,9 @@ components:
         isAdmin:
           description: The true/false parameter that marks if the user is an administrator and a 'root' user. Unlike other permissions that are organized into custom roles, the admin role has a flag. Only users with 'isAdmin' set to 'true' can manage tenant settings.
           type: boolean
+        isTenantOwner:
+          description: The true/false parameter that marks if the user is an owner of its tenant.
+          type: boolean
         useTwoFa:
           description: The true/false parameter that indicates if 2FA is enabled for the user.
           type: boolean

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -1736,7 +1736,7 @@ components:
         isAdmin:
           description: The true/false parameter that marks if the user is an administrator and a 'root' user. Unlike other permissions that are organized into custom roles, the admin role has a flag. Only users with 'isAdmin' set to 'true' can manage tenant settings.
           type: boolean
-        isTenantOwner:
+        isOwner:
           description: The true/false parameter that marks if the user is an owner of its tenant.
           type: boolean
         useTwoFa:


### PR DESCRIPTION
This PR adds a tenant owner identifier for users. The identifier can be get as part of User info but it's not possible to update it. Hub maintains that status internally.
