### PR TITLE
[INT-352] Balance API for the Hub

### DIFF
--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -25,6 +25,9 @@ tags:
   - name: Auth
     description: |
       Inperium enables you to authenticate with the Bearer token or an API key.
+  - name: Balances
+    description: |
+     Balances are used to cover metered charges such as Inperium Talk calling or SMS credits. The balance is recharged automatically when it drops below a certain threshold.
   - name: Dictionaries
     description: |
       Dictionaries are preset lists of values such as permissions or currencies that you can choose from when configuring the product.
@@ -1001,10 +1004,60 @@ paths:
               schema:
                 $ref: "#/components/schemas/ResponseError"
 
+  /tenants/{id}/balance:
+    get:
+      tags:
+        - Balances
+      summary: Retrieve a tenants balance
+      description: Use this endpoint to get information about the balance of the tenant.
+      operationId: getBalance
+      parameters:
+        - $ref: "#/components/parameters/ResourceId"
+      responses:
+        200:
+          description: Returns the Balance object.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Balance"
+        default:
+          description: Bad request, security violation, or internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+    patch:
+      summary: Update the balance settings of the tenant
+      description: Use this endpoint to update the balance settings of a tenant for metered charges.
+      operationId: updatePartialBalance
+      tags:
+        - Balances
+      parameters:
+        - $ref: "#/components/parameters/ResourceId"
+      requestBody:
+        description: In the request body, pass the BalancePartialRequest object.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BalancePartialRequest"
+      responses:
+        200:
+          description: Returns the updated balance record.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Balance"
+        default:
+          description: Bad request, security violation, or internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+
   /tenants/{id}/balance/charges:
     post:
       summary: Charge the balance of the tenant
-      description: Use this endpoint to charge the balance of a tenant for a volume-based product.
+      description: Use this endpoint to charge the balance of a tenant for a metered product.
       operationId: chargeBalance
       tags:
         - Balances
@@ -2312,19 +2365,19 @@ components:
       description: The object contains the tenant's balance information.
       properties:
         minimumAmount:
-          type: string
+          type: number
           format: double
           description: The minimum amount that needs to be on the tenants balance at all times. If the current amount drops below this amount, it will automatically recharge the balance by the amount specified in the recharge amount property.
         rechargeAmount:
-          type: string
+          type: number
           format: double
           description: The amount that will be charged on the tenants payment method if the balances current amount drops below the minimum amount.
         currency:
           $ref: '#/components/schemas/Currency'
         currentAmount:
-          type: string
+          type: number
           format: double
-          description: The current amount of money that is on the tenants balance. This can be used for any volume-based charges such as Inperium Talk calling or SMS credits.
+          description: The current amount of money that is on the tenants balance. This can be used for any metered charges such as Inperium Talk calling or SMS credits.
 
     BalancePartialRequest:
       type: object
@@ -2342,6 +2395,9 @@ components:
     BalanceChargeRequest:
       type: object
       description: The object contains the request model to charge the balance of a tenant.
+      required:
+        - product
+        - quantity
       properties:
         product:
           type: string

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -974,19 +974,19 @@ paths:
               schema:
                 $ref: "#/components/schemas/ResponseError"
     patch:
-      summary: Charge the balance of the tenant
-      description: Use this endpoint to charge the balance of a tenant for a volume-based product.
-      operationId: chargeBalance
+      summary: Update the balance settings of the tenant
+      description: Use this endpoint to update the balance settings of a tenant for volume-based charges.
+      operationId: updatePartialBalance
       tags:
         - Balances
       parameters:
         - $ref: "#/components/parameters/ResourceId"
       requestBody:
-        description: In the request body, pass the BalanceChargeRequest object.
+        description: In the request body, pass the BalancePartialRequest object.
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/BalanceChargeRequest"
+              $ref: "#/components/schemas/BalancePartialRequest"
       responses:
         200:
           description: Returns the updated balance record.
@@ -2325,6 +2325,19 @@ components:
           type: string
           format: double
           description: The current amount of money that is on the tenants balance. This can be used for any volume-based charges such as Inperium Talk calling or SMS credits.
+
+    BalancePartialRequest:
+      type: object
+      description: The object contains the request model to update the balance settings of a tenant.
+      properties:
+        minimumAmount:
+          type: number
+          format: double
+          description: The minimum amount that needs to be on the tenants balance at all times. If the current amount drops below this amount, it will automatically recharge the balance by the amount specified in the recharge amount property.
+        rechargeAmount:
+          type: number
+          format: double
+          description: The amount that will be charged on the tenants payment method if the balances current amount drops below the minimum amount.
 
     BalanceChargeRequest:
       type: object

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2282,8 +2282,6 @@ components:
       type: object
       description: The object contains the tenant's balance information.
       properties:
-        id:
-          $ref: "#/components/schemas/Id"
         minimumAmount:
           type: string
           format: double

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -1001,6 +1001,35 @@ paths:
               schema:
                 $ref: "#/components/schemas/ResponseError"
 
+  /tenants/{id}/balance/charges:
+    post:
+      summary: Charge the balance of the tenant
+      description: Use this endpoint to charge the balance of a tenant for a volume-based product.
+      operationId: chargeBalance
+      tags:
+        - Balances
+      parameters:
+        - $ref: "#/components/parameters/ResourceId"
+      requestBody:
+        description: In the request body, pass the BalanceChargeRequest object.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BalanceChargeRequest"
+      responses:
+        200:
+          description: Returns the updated balance record.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Balance"
+        default:
+          description: Bad request, security violation, or internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+
   /tenants/companyInfo:
     put:
       tags:

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2291,8 +2291,7 @@ components:
           format: double
           description: The amount that will be charged on the tenants payment method if the balances current amount drops below the minimum amount.
         currency:
-          type: string
-          description: The currency the balance is in.
+          $ref: '#/components/schemas/Currency'
         currentAmount:
           type: string
           format: double

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2307,6 +2307,11 @@ components:
     Balance:
       type: object
       description: The object contains the tenant's balance information.
+      required:
+        - minimumAmount
+        - rechargeAmount
+        - currency
+        - currentAmount
       properties:
         minimumAmount:
           type: number

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2251,6 +2251,28 @@ components:
           description: The year the card expires.
           format: int64
 
+    Balance:
+      type: object
+      description: The object contains the tenant's balance information.
+      properties:
+        id:
+          $ref: "#/components/schemas/Id"
+        minimumAmount:
+          type: string
+          format: double
+          description: The minimum amount that needs to be on the tenants balance at all times. If the current amount drops below this amount, it will automatically recharge the balance by the amount specified in the recharge amount property.
+        rechargeAmount:
+          type: string
+          format: double
+          description: The amount that will be charged on the tenants payment method if the balances current amount drops below the minimum amount.
+        currency:
+          type: string
+          description: The currency the balance is in.
+        currentAmount:
+          type: string
+          format: double
+          description: The current amount of money that is on the tenants balance. This can be used for any volume-based charges such as Inperium Talk calling or SMS credits.
+
     Permission:
       type: object
       description: The Permission object ties permission to a feature.

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -973,6 +973,33 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResponseError"
+    patch:
+      summary: Charge the balance of the tenant
+      description: Use this endpoint to charge the balance of a tenant for a volume-based product.
+      operationId: chargeBalance
+      tags:
+        - Balances
+      parameters:
+        - $ref: "#/components/parameters/ResourceId"
+      requestBody:
+        description: In the request body, pass the BalanceChargeRequest object.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BalanceChargeRequest"
+      responses:
+        200:
+          description: Returns the updated balance record.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Balance"
+        default:
+          description: Bad request, security violation, or internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
 
   /tenants/companyInfo:
     put:
@@ -2272,6 +2299,18 @@ components:
           type: string
           format: double
           description: The current amount of money that is on the tenants balance. This can be used for any volume-based charges such as Inperium Talk calling or SMS credits.
+
+    BalanceChargeRequest:
+      type: object
+      description: The object contains the request model to charge the balance of a tenant.
+      properties:
+        product:
+          type: string
+          description: The anchor of the product which should be charged.
+        quantity:
+          type: integer
+          format: int64
+          description: The quantity of the product that should be charged. For example, pass in 5 for 5 minutes of Inperium Talk calling credits.
 
     Permission:
       type: object

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -976,33 +976,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResponseError"
-    patch:
-      summary: Update the balance settings of the tenant
-      description: Use this endpoint to update the balance settings of a tenant for volume-based charges.
-      operationId: updatePartialBalance
-      tags:
-        - Balances
-      parameters:
-        - $ref: "#/components/parameters/ResourceId"
-      requestBody:
-        description: In the request body, pass the BalancePartialRequest object.
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/BalancePartialRequest"
-      responses:
-        200:
-          description: Returns the updated balance record.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Balance"
-        default:
-          description: Bad request, security violation, or internal server error.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ResponseError"
 
   /tenants/{id}/balance:
     get:
@@ -1040,35 +1013,6 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/BalancePartialRequest"
-      responses:
-        200:
-          description: Returns the updated balance record.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Balance"
-        default:
-          description: Bad request, security violation, or internal server error.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ResponseError"
-
-  /tenants/{id}/balance/charges:
-    post:
-      summary: Charge the balance of the tenant
-      description: Use this endpoint to charge the balance of a tenant for a metered product.
-      operationId: chargeBalance
-      tags:
-        - Balances
-      parameters:
-        - $ref: "#/components/parameters/ResourceId"
-      requestBody:
-        description: In the request body, pass the BalanceChargeRequest object.
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/BalanceChargeRequest"
       responses:
         200:
           description: Returns the updated balance record.
@@ -2391,21 +2335,6 @@ components:
           type: number
           format: double
           description: The amount that will be charged on the tenants payment method if the balances current amount drops below the minimum amount.
-
-    BalanceChargeRequest:
-      type: object
-      description: The object contains the request model to charge the balance of a tenant.
-      required:
-        - product
-        - quantity
-      properties:
-        product:
-          type: string
-          description: The anchor of the product which should be charged.
-        quantity:
-          type: integer
-          format: int64
-          description: The quantity of the product that should be charged. For example, pass in 5 for 5 minutes of Inperium Talk calling credits.
 
     Permission:
       type: object


### PR DESCRIPTION
This pull request adds new API endpoints to manage balances and funds for tenants in the Hub. A balance holds an amount of credits or funds for the tenant, which then can be used to pay for certain metered charges such as Inperium Talk SMS or Calling credits. That way we do not need to initiate hundreds of micro-charges to the tenants payment method, such as $0.12 for a short phone call. Instead, we charge the tenant e.g. $20 and then they can pay with these $20 for any small metered charges.

@olyavertwist can you please review the descriptions? 