### PR TITLE
Add an end-point to register new consumption of a feature

### DIFF
--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -1149,6 +1149,50 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResponseError"
+ 
+  /features/{anchor}/usage:
+    post:
+      summary: Register a usage of a feature.
+      description: |
+        Use this endpoint to inform Hub about the consumption of the feature. 
+        As a result, Hub can restrict the use of the feature or withdraw money from the tenant's balance. 
+      operationId: createFeatureUsage
+      tags:
+        - Features
+      parameters:
+        - name: anchor
+          in: path
+          description: A unique anchor of feature.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Returns the feature record.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Feature"
+        402:
+          description: |
+            Use of the function is restricted because the feature is an add-on and withdrawing from the balance failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Feature"
+        403:
+          description: |
+            Use of the function is restricted because the feature is limited and the limit is exceeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Feature"
+        default:
+          description: Bad request, security violation, or internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
 
   /permissions:
     get:


### PR DESCRIPTION
This draft shows a uniform interface to register the consumption of a feature. It's the uniform one because it encapsulates
- Update of the usage value if necessary
- Check whether the limit (if any) is exceeded
- Withdraw money from the balance if necessary

As a result, clients do not care about any limitation or price model the feature has.
The PR still lacks 
- Request model that will include at least quantity.
- Response model. Ideally, it should contain information about the current usage level and limit if they are set.
