### PR TITLE
[INT-353] API to get/create/update features usage

### DIFF
--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -426,6 +426,103 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResponseError"
+
+  /features/{anchor}/usages:
+    post:
+      summary: Register a new usage of a feature.
+      description: |
+        Use this endpoint to inform the Hub about a new consumption of a feature.
+        As a result, the Hub can restrict the use of the feature or withdraw money from the tenant's balance.
+      operationId: createFeatureUsage
+      tags:
+      - Features
+      parameters:
+      - name: anchor
+        in: path
+        description: A unique anchor of the feature.
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FeatureUsageRequest"
+      responses:
+        200:
+          description: Returns the feature record.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlanFeature"
+        402:
+          description: |
+            Use of the function is restricted because the feature is an add-on and withdrawing from the balance failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlanFeature"
+        403:
+          description: |
+            Use of the function is restricted because the feature is limited and the limit is exceeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlanFeature"
+        default:
+          description: Bad request, security violation, or internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+    put:
+      summary: Update an amount of usage of a feature.
+      description: |
+        Use this endpoint to update the amount of consumption of a feature.
+        As a result, if the given value overtops the previous one, the Hub can restrict the use of the feature or withdraw money from the tenant's balance.
+      operationId: updateFeatureUsage
+      tags:
+      - Features
+      parameters:
+      - name: anchor
+        in: path
+        description: A unique anchor of the feature.
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FeatureUsageRequest"
+      responses:
+        200:
+          description: Returns the feature record.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlanFeature"
+        402:
+          description: |
+            Use of the function is restricted because the feature is an add-on and withdrawing from the balance failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlanFeature"
+        403:
+          description: |
+            Use of the function is restricted because the feature is limited and the limit is exceeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlanFeature"
+        default:
+          description: Bad request, security violation, or internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+
   /health:
     get:
       tags:
@@ -2465,6 +2562,38 @@ components:
         product:
           type: string
           description: The Inperium app.
+
+    FeatureUsageRequest:
+      type: object
+      description: | 
+        The incoming object sent by Inperium services to Hub when a feature usage is updated outside the Hub. 
+        For example, you make internaltional call (in Inperium Talk) and the feature usage must be updated.
+      properties:
+        quantity:
+          type: integer
+          format: int64
+          minimum: 0
+          description: | 
+            The quantity of consumed feature. It can be either the total amount of feature usage or its increment. 
+            It depends on the end-point that is in use.
+
+    PlanFeature:
+      type: object
+      description: The PlanFeature object describes the feature in the plan you have including consumed quantity, its limitation, etc. 
+      properties:
+        plan:
+          $ref: "#/components/schemas/Plan"
+        feature:
+          $ref: "#/components/schemas/Feature"
+        priceModel:
+          type: string
+        isInfinite:
+          type: boolean
+          description: The true/false parameter that identifies if the limit is active. Set this parameter to 'true' to provide unlimited access to a product feature (anchor). For example, support an infinite number of templates.
+        thresholdValue:
+          type: integer
+          format: int64
+          description: The maximum value allowed by the Limit.
 
     Plan:
       type: object

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -1183,7 +1183,7 @@ paths:
           type: string
       requestBody:
         content:
-          application/json:
+          "*/*":
             schema:
               $ref: "#/components/schemas/FeatureUsageRequest"
       responses:
@@ -1231,7 +1231,7 @@ paths:
           type: string
       requestBody:
         content:
-          application/json:
+          "*/*":
             schema:
               $ref: "#/components/schemas/FeatureUsageRequest"
       responses:

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -1143,7 +1143,7 @@ paths:
         Use this endpoint to get information about the usage of a feature.
       operationId: getFeatureUsage
       tags:
-      - Tenants
+      - Features
       parameters:
       - name: anchor
         in: path
@@ -1177,7 +1177,7 @@ paths:
         As a result, the Hub can restrict the use of the feature or withdraw money from the tenant's balance.
       operationId: createFeatureUsage
       tags:
-      - Tenants
+      - Features
       parameters:
       - name: anchor
         in: path
@@ -1224,7 +1224,7 @@ paths:
         the Hub will restrict the use of the feature or withdraw money from the tenant's balance.
       operationId: updateFeatureUsage
       tags:
-      - Tenants
+      - Features
       parameters:
       - name: anchor
         in: path
@@ -2608,7 +2608,7 @@ components:
 
     FeatureUsageRequest:
       type: object
-      description: | 
+      description: |
         The incoming object sent by Inperium services to Hub when a feature usage is updated outside the Hub. 
         For example, you make an international call.
       properties:
@@ -2616,7 +2616,7 @@ components:
           type: integer
           format: int64
           minimum: 0
-          description: | 
+          description: |
             The number demonstrating how many times the feature was consumed. Depending on the endpoint that is in use, 
             the quantity can be either the total feature usage count or its increment.
         userId:

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2612,7 +2612,6 @@ components:
             the quantity can be either the total feature usage count or its increment.
         userId:
           $ref: "#/components/schemas/Id"
-          description: A unique identifier of the user who consumed the feature.
 
     FeatureUsage:
       type: object
@@ -2800,15 +2799,59 @@ components:
         licensedQuantity:
           type: integer
           format: int64
-          description: The number of used licenses.
+          deprecated: true
+          description: |
+            The number of used licenses of the related product. The property is deprecated because it's being migrated
+            to a subscription item with type PRODUCT.
         quantity:
           type: integer
           format: int64
-          description: The number of available licenses. If the overall number of purchased licenses exceed the 'licensedQuantity', it indicates that some license aren't currently in use. You can leverage this licenses by inviting more users.
+          deprecated: true
+          description: |
+            The number of available licenses. If the overall number of purchased licenses exceed the 'licensedQuantity',
+            it indicates that some license aren't currently in use. You can leverage this licenses by inviting more users.
+            The property is deprecated because it's being migrated to a subscription item with type PRODUCT.
         discountAmount:
           type: number
           format: double
           description: The discount applied to the subscription.
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/SubscriptionItem"
+
+    SubscriptionItem:
+      type: object
+      description: The object contains information about the tenant's active plan, product or add-on usage, etc.
+      discriminator:
+        propertyName: schema
+      required:
+        - id
+        - price
+        - licensedQuantity
+        - quantity
+        - type
+      properties:
+        id:
+          $ref: "#/components/schemas/Id"
+        price:
+          $ref: "#/components/schemas/Price"
+        licensedQuantity:
+          type: integer
+          format: int64
+          description: The number of used licenses.
+        quantity:
+          type: integer
+          format: int64
+          description: |
+            The number of available licenses. If the overall number of purchased licenses exceed the 'licensedQuantity',
+            it indicates that some license aren't currently in use. You can leverage this licenses by inviting more users.
+        type:
+          type: string
+          enum:
+            - PRODUCT
+            - ADDON
+          description: The type identifies whether the item relates to a product or one of its add-on.
 
     SubscriptionRequest:
       type: object

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -1138,13 +1138,12 @@ paths:
 
   /tenants/features/{anchor}/usages:
     get:
-      summary: Retrieve information about usage of a feature.
+      summary: Retrieve the feature usage
       description: |
-        Use this endpoint to get information about usage of a feature.
+        Use this endpoint to get information about the usage of a feature.
       operationId: getFeatureUsage
       tags:
       - Tenants
-      - Features
       parameters:
       - name: anchor
         in: path
@@ -1166,14 +1165,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/ResponseError"
     post:
-      summary: Register a new usage of a feature.
+      summary: Register a feature usage
       description: |
         Use this endpoint to inform the Hub about a new consumption of a feature.
         As a result, the Hub can restrict the use of the feature or withdraw money from the tenant's balance.
       operationId: createFeatureUsage
       tags:
       - Tenants
-      - Features
       parameters:
       - name: anchor
         in: path
@@ -1183,7 +1181,7 @@ paths:
           type: string
       requestBody:
         content:
-          "*/*":
+          application/json:
             schema:
               $ref: "#/components/schemas/FeatureUsageRequest"
       responses:
@@ -1214,14 +1212,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/ResponseError"
     put:
-      summary: Update an amount of usage of a feature.
+      summary: Update the usage count
       description: |
-        Use this endpoint to update the amount of consumption of a feature.
-        As a result, if the given value overtops the previous one, the Hub can restrict the use of the feature or withdraw money from the tenant's balance.
+        Use this endpoint to update the counter. If the feature consumption value overtops the previous one, 
+        the Hub will restrict the use of the feature or withdraw money from the tenant's balance.
       operationId: updateFeatureUsage
       tags:
       - Tenants
-      - Features
       parameters:
       - name: anchor
         in: path
@@ -1231,7 +1228,7 @@ paths:
           type: string
       requestBody:
         content:
-          "*/*":
+          application/json:
             schema:
               $ref: "#/components/schemas/FeatureUsageRequest"
       responses:
@@ -2598,37 +2595,40 @@ components:
       type: object
       description: | 
         The incoming object sent by Inperium services to Hub when a feature usage is updated outside the Hub. 
-        For example, you make internaltional call (in Inperium Talk) and the feature usage must be updated.
+        For example, you make an international call.
       properties:
         quantity:
           type: integer
           format: int64
           minimum: 0
           description: | 
-            The quantity of consumed feature. It can be either the total amount of feature usage or its increment. 
-            It depends on the end-point that is in use.
+            The number demonstrating how many times the feature was consumed. Depending on the endpoint that is in use, 
+            the quantity can be either the total feature usage count or its increment.
 
     FeatureUsage:
       type: object
-      description: The PlanFeature object describes the feature in the plan you have including consumed quantity, its limitation, etc. 
+      description: The FeatureUsage object describes the feature in the plan you have.
+      required:
+        - plan
+        - feature
       properties:
         plan:
           $ref: "#/components/schemas/Plan"
         feature:
           $ref: "#/components/schemas/Feature"
-        priceModel:
-          type: string
-        isInfinite:
-          type: boolean
-          description: The true/false parameter that identifies if the limit is active. Set this parameter to 'true' to provide unlimited access to a product feature (anchor). For example, support an infinite number of templates.
-        thresholdValue:
-          type: integer
-          format: int64
-          description: The maximum value allowed by the Limit.
+        priceModels:
+          type: array
+          description: |
+            Depending on the endpoint that is in use, the price models are either the available models in the plan or the used price model.
+          items:
+            type: string
+            enum:
+              - STANDARD
+              - METERED
         currentValue:
           type: integer
           format: int64
-          description: The counter, it displays how close you are to reaching the threshold.
+          description: The current value of the feature usage for the tenant.
 
     Plan:
       type: object

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2032,7 +2032,16 @@ components:
             type: string
         subscriptionIds:
           type: array
-          description: The list of subscriptions enabled for the user.
+          description: |
+            The list of subscriptions enabled for the user. If no subscription items are set,
+            then only the PRODUCT item will be assigned.
+          items:
+            $ref: "#/components/schemas/Id"
+        subscriptionItemIds:
+          type: array
+          description: |
+            The list of subscription items enabled for the user. The items should be set with their subscriptions.
+            Otherwise, the property is ignored.
           items:
             $ref: "#/components/schemas/Id"
 

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -427,102 +427,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/ResponseError"
 
-  /features/{anchor}/usages:
-    post:
-      summary: Register a new usage of a feature.
-      description: |
-        Use this endpoint to inform the Hub about a new consumption of a feature.
-        As a result, the Hub can restrict the use of the feature or withdraw money from the tenant's balance.
-      operationId: createFeatureUsage
-      tags:
-      - Features
-      parameters:
-      - name: anchor
-        in: path
-        description: A unique anchor of the feature.
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/FeatureUsageRequest"
-      responses:
-        200:
-          description: Returns the feature record.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlanFeature"
-        402:
-          description: |
-            Use of the function is restricted because the feature is an add-on and withdrawing from the balance failed.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlanFeature"
-        403:
-          description: |
-            Use of the function is restricted because the feature is limited and the limit is exceeded.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlanFeature"
-        default:
-          description: Bad request, security violation, or internal server error.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ResponseError"
-    put:
-      summary: Update an amount of usage of a feature.
-      description: |
-        Use this endpoint to update the amount of consumption of a feature.
-        As a result, if the given value overtops the previous one, the Hub can restrict the use of the feature or withdraw money from the tenant's balance.
-      operationId: updateFeatureUsage
-      tags:
-      - Features
-      parameters:
-      - name: anchor
-        in: path
-        description: A unique anchor of the feature.
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/FeatureUsageRequest"
-      responses:
-        200:
-          description: Returns the feature record.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlanFeature"
-        402:
-          description: |
-            Use of the function is restricted because the feature is an add-on and withdrawing from the balance failed.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlanFeature"
-        403:
-          description: |
-            Use of the function is restricted because the feature is limited and the limit is exceeded.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PlanFeature"
-        default:
-          description: Bad request, security violation, or internal server error.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ResponseError"
-
   /health:
     get:
       tags:
@@ -1231,6 +1135,133 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResponseError"
+
+  /tenants/features/{anchor}/usages:
+    get:
+      summary: Retrieve information about usage of a feature.
+      description: |
+        Use this endpoint to get information about usage of a feature.
+      operationId: getFeatureUsage
+      tags:
+      - Tenants
+      - Features
+      parameters:
+      - name: anchor
+        in: path
+        description: A unique anchor of the feature.
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Returns the feature record.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeatureUsage"
+        default:
+          description: Bad request, security violation, or internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+    post:
+      summary: Register a new usage of a feature.
+      description: |
+        Use this endpoint to inform the Hub about a new consumption of a feature.
+        As a result, the Hub can restrict the use of the feature or withdraw money from the tenant's balance.
+      operationId: createFeatureUsage
+      tags:
+      - Tenants
+      - Features
+      parameters:
+      - name: anchor
+        in: path
+        description: A unique anchor of the feature.
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FeatureUsageRequest"
+      responses:
+        200:
+          description: Returns the feature record.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeatureUsage"
+        402:
+          description: |
+            Use of the function is restricted because the feature is an add-on and withdrawing from the balance failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+        403:
+          description: |
+            Use of the function is restricted because the feature is limited and the limit is exceeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+        default:
+          description: Bad request, security violation, or internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+    put:
+      summary: Update an amount of usage of a feature.
+      description: |
+        Use this endpoint to update the amount of consumption of a feature.
+        As a result, if the given value overtops the previous one, the Hub can restrict the use of the feature or withdraw money from the tenant's balance.
+      operationId: updateFeatureUsage
+      tags:
+      - Tenants
+      - Features
+      parameters:
+      - name: anchor
+        in: path
+        description: A unique anchor of the feature.
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FeatureUsageRequest"
+      responses:
+        200:
+          description: Returns the feature record.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeatureUsage"
+        402:
+          description: |
+            Use of the function is restricted because the feature is an add-on and withdrawing from the balance failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+        403:
+          description: |
+            Use of the function is restricted because the feature is limited and the limit is exceeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+        default:
+          description: Bad request, security violation, or internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+
   /users:
     post:
       tags:
@@ -2577,7 +2608,7 @@ components:
             The quantity of consumed feature. It can be either the total amount of feature usage or its increment. 
             It depends on the end-point that is in use.
 
-    PlanFeature:
+    FeatureUsage:
       type: object
       description: The PlanFeature object describes the feature in the plan you have including consumed quantity, its limitation, etc. 
       properties:
@@ -2594,6 +2625,10 @@ components:
           type: integer
           format: int64
           description: The maximum value allowed by the Limit.
+        currentValue:
+          type: integer
+          format: int64
+          description: The counter, it displays how close you are to reaching the threshold.
 
     Plan:
       type: object

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2688,6 +2688,9 @@ components:
           type: number
           description: The sum to be paid according to this plan.
           format: double
+        name:
+          type: string
+          description: The name of the price.
         interval:
           $ref: "#/components/schemas/PriceInterval"
         intervalCount:

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -1151,6 +1151,12 @@ paths:
         required: true
         schema:
           type: string
+      - name: userId
+        in: query
+        description: A unique identifier of the user.
+        required: false
+        schema:
+          $ref: "#/components/schemas/Id"
       responses:
         200:
           description: Returns the feature record.
@@ -2604,6 +2610,9 @@ components:
           description: | 
             The number demonstrating how many times the feature was consumed. Depending on the endpoint that is in use, 
             the quantity can be either the total feature usage count or its increment.
+        userId:
+          $ref: "#/components/schemas/Id"
+          description: A unique identifier of the user who consumed the feature.
 
     FeatureUsage:
       type: object


### PR DESCRIPTION
It's a fair copy of [the previous PR about updating feature usage](https://github.com/inperium-corp/inperium-openapi/pull/158) (this time, it's based on the development branch). The PR still shows a uniform interface to register/update the consumption of a feature. It's the uniform one because it encapsulates
- Update of the usage value if necessary
- Check whether the limit (if any) is exceeded
- Withdraw money from the balance if necessary.

The main differences from the previous one are:
- The end-points are moved to /tenants/ path because they are about changing data related to the tenant.
- Now Hub supports not only increments of the usages but also setting the absolute value of it. It's necessary, for example, for Calls.
- Some fixes basing on the feedback are included.

Please note that it's still a draft. At least the following details to be added:
- Now tenants can have more than one subscription. 
- Add-ons can have their prices.
- Subscription can have more than one price (main product and add-ons).

It all should be reflected in this API.

@olyavertwist , I hope, the descriptions fit our common style.