### PR TITLE
[INS-3294] Add better validation for the quote endpoints

### DIFF
--- a/sell/sell-api.yaml
+++ b/sell/sell-api.yaml
@@ -5763,11 +5763,11 @@ components:
         comment:
           type: string
           description: Any additional details.
-          maxLength: 1000
+          maxLength: 2000
         purchaseTerm:
           type: string
           description: The purchasing terms.
-          maxLength: 1000
+          maxLength: 5000
         companyId:
           $ref: "#/components/schemas/Id"
         value:

--- a/sell/sell-api.yaml
+++ b/sell/sell-api.yaml
@@ -4093,9 +4093,11 @@ components:
         name:
           type: string
           description: The fee title.
+          maxLength: 64
         type:
           type: string
           description: The fee type.
+          maxLength: 32
     Attachment:
       type: object
       properties:
@@ -5738,12 +5740,16 @@ components:
       description: The Quote object returned by Inperium API contains information about the quote such as its name and value, included products and fees.
     QuoteRequest:
       type: object
+      description: This object is submitted to Inperium API when you create a new quote or update an existing quote.
+      required:
+        - status
       properties:
         id:
           $ref: "#/components/schemas/Id"
         name:
           type: string
           description: The quote title.
+          maxLength: 100
         dealId:
           $ref: "#/components/schemas/Id"
         expirationDate:
@@ -5757,9 +5763,11 @@ components:
         comment:
           type: string
           description: Any additional details.
+          maxLength: 1000
         purchaseTerm:
           type: string
           description: The purchasing terms.
+          maxLength: 1000
         companyId:
           $ref: "#/components/schemas/Id"
         value:
@@ -5808,9 +5816,6 @@ components:
           description: The signature.
         avatarId:
           $ref: "#/components/schemas/Id"
-      required:
-        - status
-      description: This object is submitted to Inperium API when you create a new quote or update an existing quote.
     QuoteCompany:
       type: object
       properties:
@@ -5884,6 +5889,9 @@ components:
     QuoteToInvoice:
       type: object
       description: This object facilitates converting an accepted quote to an invoice.
+      required:
+        - contactId
+        - dueDate
       properties:
         contactId:
           $ref: "#/components/schemas/Id"


### PR DESCRIPTION
This pull request adds better server-side validation for the quote endpoints. Before we did not allow long names for additional fees and other parts of a quote, but we only had validation on the database layer. This PR adds it on the API level.