### PR TITLE
Add an attribute "assignable" to SubscriptionItem model

### DIFF
--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2845,6 +2845,7 @@ components:
         - licensedQuantity
         - quantity
         - type
+        - assignable
       properties:
         id:
           $ref: "#/components/schemas/Id"

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2866,6 +2866,9 @@ components:
             - PRODUCT
             - ADD_ON
           description: The type identifies whether the item relates to a product or one of its add-on.
+        assignable:
+          type: boolean
+          description: The true/false parameter defining if a user can be assigned to the item.
 
     SubscriptionRequest:
       type: object


### PR DESCRIPTION
Some of extra-fee-based features (e.g. phone number in Talk) are not assignable to users. Hub rejects partial user updates which an non-assignable subscription item (related to the features) is given. For this reason, the API clients (e.g. UI) should know whether an item is assignable or not.