### PR TITLE
Add proper validation to the balance request

### DIFF
--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2473,9 +2473,6 @@ components:
     BalancePartialRequest:
       type: object
       description: The object contains the request model to update the balance settings of a tenant.
-      required:
-        - minimumAmount
-        - rechargeAmount
       properties:
         minimumAmount:
           type: number

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2473,14 +2473,21 @@ components:
     BalancePartialRequest:
       type: object
       description: The object contains the request model to update the balance settings of a tenant.
+      required:
+        - minimumAmount
+        - rechargeAmount
       properties:
         minimumAmount:
           type: number
           format: double
+          minimum: 10
+          maximum: 100
           description: The minimum amount that needs to be on the tenants balance at all times. If the current amount drops below this amount, it will automatically recharge the balance by the amount specified in the recharge amount property.
         rechargeAmount:
           type: number
           format: double
+          minimum: 20
+          maximum: 200
           description: The amount that will be charged on the tenants payment method if the balances current amount drops below the minimum amount.
 
     Permission:


### PR DESCRIPTION
This PR adds proper validation to the balance requests. We were missing the required, minimum and maximum validators on the API level.