### PR TITLE
[IBA-111] Rework the feature usages interface and add one for the balance charges

### DIFF
--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -1244,6 +1244,13 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResponseError"
+        403:
+          description: |
+            Use of the function is restricted because the feature is limited and the limit is exceeded.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
         default:
           description: Bad request, security violation, or internal server error.
           content:
@@ -1280,6 +1287,13 @@ paths:
         402:
           description: |
             Use of the function is restricted because the feature is an add-on and withdrawing from the balance failed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+        403:
+          description: |
+            Use of the function is restricted because the feature is limited and the limit is exceeded.
           content:
             application/json:
               schema:

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2584,6 +2584,9 @@ components:
           minimum: 20
           maximum: 200
           description: The amount that will be charged on the tenants payment method if the balances current amount drops below the minimum amount.
+        isActive:
+          type: boolean
+          description: The true/false parameter that marks if the balance is active. Making balance active allows using metered add-ons.
 
     Permission:
       type: object

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2487,6 +2487,7 @@ components:
         - rechargeAmount
         - currency
         - currentAmount
+        - active
       properties:
         minimumAmount:
           type: number
@@ -2502,6 +2503,9 @@ components:
           type: number
           format: double
           description: The current amount of money that is on the tenants balance. This can be used for any metered charges such as Inperium Talk calling or SMS credits.
+        isActive:
+          description: The true/false parameter that marks if the balance is active. A reason for the inactive state can be a failed attempt to add a fund to the balance. 
+          type: boolean
 
     BalanceCharge:
       type: object

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -3041,7 +3041,7 @@ components:
 
     PlanFeature:
       type: object
-      description: TODO
+      description: The plan-feature object defines additional information of the feature in the plan.
       required:
         - id
         - plan

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2507,8 +2507,13 @@ components:
       type: object
       description: The object contains the tenant's balance charge information.
       required:
+        - id
         - grossAmount
+        - createAt
+        - updatedAt
       properties:
+        id:
+          $ref: "#/components/schemas/Id"
         grossAmount:
           type: number
           format: double
@@ -2525,6 +2530,14 @@ components:
           type: object
           additionalProperties: true
           description: Additional information about the charge. For example, it can be infortmation about addressee of a call in Inperium Talk.
+        createdAt:
+          type: integer
+          description: The date the charge was recorded.
+          format: int64
+        updatedAt:
+          type: integer
+          description: The date the charge was modified.
+          format: int64
 
     BalanceCharges:
       type: object

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2955,6 +2955,7 @@ components:
         - id
         - plan
         - feature
+        - assignable
       properties:
         id:
           $ref: "#/components/schemas/Id"
@@ -2965,7 +2966,7 @@ components:
         priceModel:
           description: The object defines what price model the feature has in the plan. Having no model means that the feature is free in the plan.
           $ref: "#/components/schemas/FeaturePriceModel"
-        isAssignable:
+        assignable:
           type: boolean
           description: The true/false parameter that marks if the feature can be assigned to users.
 

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2651,6 +2651,7 @@ components:
           $ref: "#/components/schemas/Id"
         metadata:
           type: object
+          additionalProperties: true
           description: The objects defines an extra information about the usage. For example, an addressee of a call.
 
     FeatureUsage:

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2526,24 +2526,24 @@ components:
       description: The object contains the tenant's balance charge information.
       required:
         - id
-        - grossAmount
+        - netAmount
         - createAt
         - updatedAt
       properties:
         id:
           $ref: "#/components/schemas/Id"
-        grossAmount:
+        netAmount:
           type: number
           format: double
-          description: The gross amount of the charge. 
+          description: The net amount of the charge.
         taxAmount:
           type: number
           format: double
-          description: The tax amount of the charge. 
-        totalAmount:
+          description: The tax amount of the charge.
+        grossAmount:
           type: number
           format: double
-          description: The total amount of the charge.
+          description: The gross amount of the charge.
         metadata:
           type: object
           additionalProperties: true

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2621,11 +2621,20 @@ components:
           type: string
           description: The Inperium app.
 
+    FeaturePriceModel:
+      type: string
+      enum:
+        - STANDARD
+        - METERED
+      description: The FeaturePriceModel object defines what price model the feature has.
+
     FeatureUsageRequest:
       type: object
       description: |
         The incoming object sent by Inperium services to Hub when a feature usage is updated outside the Hub.
         For example, you make an international call.
+      required:
+        - quantity
       properties:
         quantity:
           type: integer
@@ -2635,32 +2644,25 @@ components:
             The number demonstrating how many times the feature was consumed. Depending on the endpoint that is in use,
             the quantity can be either the total feature usage count or its increment.
         userId:
+          description: The id defines the user who consumped the feature. This attribute is mandatory for assignable features.
+          $ref: "#/components/schemas/Id"
+        usageExternalId:
+          description: The id defines an external id of the usage, i.e. a reference to an external event. The id can be used for updating already created usage.
           $ref: "#/components/schemas/Id"
 
     FeatureUsage:
       type: object
       description: The FeatureUsage object describes the feature in the plan you have.
       required:
-        - plan
-        - feature
+        - planFeature
       properties:
-        plan:
-          $ref: "#/components/schemas/Plan"
-        feature:
-          $ref: "#/components/schemas/Feature"
-        priceModels:
-          type: array
-          description: |
-            Depending on the endpoint that is in use, the price models are either the available models in the plan or the used price model.
-          items:
-            type: string
-            enum:
-              - STANDARD
-              - METERED
-        currentValue:
-          type: integer
-          format: int64
-          description: The current value of the feature usage for the tenant.
+        planFeature:
+          $ref: "#/components/schemas/PlanFeature"
+        limit:
+          description: The object describes whether the feature has any limit in the plan for you.
+          $ref: "#/components/schemas/Limit"
+        usage:
+          $ref: "#/components/schemas/LimitUsage"
 
     Plan:
       type: object
@@ -2945,6 +2947,27 @@ components:
         - PAST_DUE
         - CANCELED
       description: The state of the subscription. This is the enum parameter.
+
+    PlanFeature:
+      type: object
+      description: TODO
+      required:
+        - id
+        - plan
+        - feature
+      properties:
+        id:
+          $ref: "#/components/schemas/Id"
+        plan:
+          $ref: "#/components/schemas/Plan"
+        feature:
+          $ref: "#/components/schemas/Feature"
+        priceModel:
+          description: The object defines what price model the feature has in the plan. Having no model means that the feature is free in the plan.
+          $ref: "#/components/schemas/FeaturePriceModel"
+        isAssignable:
+          type: boolean
+          description: The true/false parameter that marks if the feature can be assigned to users.
 
     PlanFullInfo:
       type: object

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -1030,6 +1030,44 @@ paths:
               schema:
                 $ref: "#/components/schemas/ResponseError"
 
+  /tenants/{id}/balance/charges:
+    get:
+      tags:
+        - Balances
+      summary: Retrieve balance charges
+      description: Use this endpoint to get information about the balance charges of the tenant.
+      operationId: getBalanceCharges
+      parameters:
+        - $ref: "#/components/parameters/ResourceId"
+        - name: from
+          in: query
+          description: The start date.
+          schema:
+            type: integer
+            format: int64
+        - name: to
+          in: query
+          description: The finish date.
+          schema:
+            type: integer
+            format: int64
+        - $ref: "#/components/parameters/QueryPageNumber"
+        - $ref: "#/components/parameters/QueryPageSize"
+        - $ref: "#/components/parameters/QuerySort"
+      responses:
+        200:
+          description: Returns the Balance Charges object.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BalanceCharges"
+        default:
+          description: Bad request, security violation, or internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+
   /tenants/companyInfo:
     put:
       tags:
@@ -1206,13 +1244,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResponseError"
-        403:
-          description: |
-            Use of the function is restricted because the feature is limited and the limit is exceeded.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ResponseError"
         default:
           description: Bad request, security violation, or internal server error.
           content:
@@ -1249,13 +1280,6 @@ paths:
         402:
           description: |
             Use of the function is restricted because the feature is an add-on and withdrawing from the balance failed.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ResponseError"
-        403:
-          description: |
-            Use of the function is restricted because the feature is limited and the limit is exceeded.
           content:
             application/json:
               schema:
@@ -2479,6 +2503,40 @@ components:
           format: double
           description: The current amount of money that is on the tenants balance. This can be used for any metered charges such as Inperium Talk calling or SMS credits.
 
+    BalanceCharge:
+      type: object
+      description: The object contains the tenant's balance charge information.
+      required:
+        - grossAmount
+      properties:
+        grossAmount:
+          type: number
+          format: double
+          description: The gross amount of the charge. 
+        taxAmount:
+          type: number
+          format: double
+          description: The tax amount of the charge. 
+        totalAmount:
+          type: number
+          format: double
+          description: The total amount of the charge.
+        metadata:
+          type: object
+          additionalProperties: true
+          description: Additional information about the charge. For example, it can be infortmation about addressee of a call in Inperium Talk.
+
+    BalanceCharges:
+      type: object
+      description: The list of available charges.
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/BalanceCharge"
+        paging:
+          $ref: "#/components/schemas/PageAndSort"
+
     BalancePartialRequest:
       type: object
       description: The object contains the request model to update the balance settings of a tenant.
@@ -2662,10 +2720,8 @@ components:
       properties:
         planFeature:
           $ref: "#/components/schemas/PlanFeature"
-        limit:
-          description: The object describes whether the feature has any limit in the plan for you.
-          $ref: "#/components/schemas/Limit"
-        usage:
+        limitUsage:
+          description: The object describes whether the feature has any limit in the plan for you and what the current state it has.
           $ref: "#/components/schemas/LimitUsage"
 
     Plan:

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2646,9 +2646,12 @@ components:
         userId:
           description: The id defines the user who consumped the feature. This attribute is mandatory for assignable features.
           $ref: "#/components/schemas/Id"
-        usageExternalId:
-          description: The id defines an external id of the usage, i.e. a reference to an external event. The id can be used for updating already created usage.
+        usageId:
+          description: The id is the identifier of a usage. The id can be used for updating already created usage.
           $ref: "#/components/schemas/Id"
+        metadata:
+          type: object
+          description: The objects defines an extra information about the usage. For example, an addressee of a call.
 
     FeatureUsage:
       type: object

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2517,7 +2517,7 @@ components:
           type: number
           format: double
           description: The current amount of money that is on the tenants balance. This can be used for any metered charges such as Inperium Talk calling or SMS credits.
-        isActive:
+        active:
           description: The true/false parameter that marks if the balance is active. A reason for the inactive state can be a failed attempt to add a fund to the balance. 
           type: boolean
 
@@ -2584,7 +2584,7 @@ components:
           minimum: 20
           maximum: 200
           description: The amount that will be charged on the tenants payment method if the balances current amount drops below the minimum amount.
-        isActive:
+        active:
           type: boolean
           description: The true/false parameter that marks if the balance is active. Making balance active allows using metered add-ons.
 


### PR DESCRIPTION
The main reason for the change is the missing tax calculation for the add-ons. Adding the calculation leads to 2 changes in the API:
* From now on, Talk (and other services) cannot post the total feature usage for a tenant/user (e.g. total duration of the calls). It has to post each consumption individually so that we can calculate tax correctly and report the clients about it in all details. 
* An extra end-point to fetch the balance charges to show the clients why the money was taken from their balances. We had to do it anyway, but the extra charge because of the taxes makes it more important.

[Link to the Jira task](https://blackbirdsoftware.atlassian.net/browse/IBA-111).