### PR TITLE
Talk descriptions

### DIFF
--- a/sell/sell-api.yaml
+++ b/sell/sell-api.yaml
@@ -147,7 +147,7 @@ tags:
       Views control what data is returned to the user, including filtering, sorting, and columns on a display.
   - name: Widgets
     description: |
-      In Inperium Sell, a widget is a dashboard element providing certain data, for example, the leader board or the number of deals on each pipeline.
+      In Inperium Sell, a widget is a dashboard element that provides certain data, for example, the leader list or the number of deals on each pipeline.
   - name: Xero Authorizations
     description: |
       Configure integration with Xero.

--- a/talk/talk-api.yaml
+++ b/talk/talk-api.yaml
@@ -1,9 +1,9 @@
 openapi: 3.0.3
 
 info:
-  title: Inperium Server Talk API
+  title: Talk API
   description: |
-    The initial version of Inperium Talk API.
+    The Inperium Talk API provides access to the Inperium Talk service including the ability to make calls, add contacts, configure auto receptionist settings, etc.
   version: 1.0.0-SNAPSHOT
 
 servers:
@@ -14,12 +14,50 @@ security:
   - BearerAuth: [ ]
   - ApiKeyAuth: [ ]
 
+tags:
+  - name: Addresses
+    description:
+  - name: Audio Files
+    description:
+  - name: Auto Receptionists
+    description:
+  - name: Calls
+    description:
+  - name: Call Callbacks
+    description:
+  - name: Contacts
+    description:
+  - name: Health Checks
+    description:
+  - name: IVR Callbacks
+    description:
+  - name: Participants
+    description:
+  - name: Phone Numbers
+    description:
+  - name: Recording Callbacks
+    description:
+  - name: Regulatory Bundles
+    description:
+  - name: Reports
+    description:
+  - name: Report Data
+    description:
+  - name: Services
+    description:
+  - name: Voicemails
+    description:
+  - name: User Settings
+    description:
+  - name: Widgets
+    description:
+
 paths:
   /health:
     get:
       tags:
         - Health Checks
-      summary: Checks the health of the microservice
+      summary: Check the health of the microservice
       operationId: checkHealth
       responses:
         200:

--- a/talk/talk-api.yaml
+++ b/talk/talk-api.yaml
@@ -70,23 +70,53 @@ tags:
     description: In Inperium Talk, widgets are dashboard elements such as charts and lists that help track your productivity.
 
 paths:
-  /health:
+
+  /addresses:
     get:
       tags:
-        - Health Checks
-      summary: Check the health of the microservice
-      operationId: checkHealth
+        - Addresses
+      summary: Retrieve addresses
+      operationId: getAddresses
+      parameters:
+        - $ref: '#/components/parameters/QueryPageNumber'
+        - $ref: '#/components/parameters/QueryPageSize'
+        - $ref: '#/components/parameters/QuerySort'
       responses:
         200:
-          description: An empty response that is used for OK non-returning operations
-          content: { }
+          description: The addresses have been retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Addresses'
         default:
           description: Bad request, security violation, or internal server error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResponseError'
-
+    post:
+      tags:
+        - Addresses
+      summary: Create a new address for the tenant
+      operationId: createAddress
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddressRequest'
+      responses:
+        201:
+          description: A new address has been created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Address'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
   /audioFiles:
     get:
       tags:
@@ -202,242 +232,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResponseError'
-
-  /services/textToSpeech:
-    post:
-      tags:
-        - Services
-      summary: Convert text into audio
-      operationId: textToSpeech
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TextToSpeechRequest'
-      responses:
-        200:
-          description: The synthesized audio
-          content:
-            audio/*:
-              schema:
-                type: string
-                format: binary
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            audio/*:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-  /services/phoneNumbersToBuy:
-    get:
-      tags:
-        - Services
-      summary: Retrieve a list of available phone numbers from Twilio
-      operationId: findPhoneNumbersAvailableToBuy
-      parameters:
-        - name: countryCode
-          in: query
-          required: true
-          schema:
-            $ref: '#/components/schemas/CountryCode'
-        - name: areaCode
-          in: query
-          description: The rate center of the phone number
-          schema:
-            type: string
-        - name: type
-          in: query
-          description: Filter phone numbers by type
-          schema:
-            $ref: '#/components/schemas/PhoneNumberType'
-      responses:
-        200:
-          description: The list of phone numbers has been retrieved
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AvailablePhoneNumber'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-
-  /phoneNumbers:
-    get:
-      tags:
-        - Phone Numbers
-      summary: Retrieve a list of phone numbers
-      operationId: getPhoneNumbers
-      parameters:
-        - name: userId
-          in: query
-          description: Filter by the user assignment
-          schema:
-            type: string
-            example: eq::fda3787b-9f4e-45e3-91a3-46d61003c2d7
-        - name: assignmentType
-          in: query
-          description: Filter by the assignment type
-          schema:
-            type: string
-            example: eq::USER
-        - name: number
-          in: query
-          description: Search parameters by the phone number
-          schema:
-            minLength: 3
-            type: string
-        - name: type
-          in: query
-          description: Filter by the phone number type
-          schema:
-            type: string
-            example: eq::LOCAL
-        - name: regulatoryStatus
-          in: query
-          description: Filter by the status of the phone number's regulatory bundle
-          schema:
-            type: string
-        - $ref: '#/components/parameters/QueryPageNumber'
-        - $ref: '#/components/parameters/QueryPageSize'
-        - $ref: '#/components/parameters/QuerySort'
-      responses:
-        200:
-          description: The phone numbers have been retrieved
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PhoneNumbers'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-    post:
-      tags:
-        - Phone Numbers
-      summary: Buy and create a list of Twilio phone numbers
-      operationId: buyPhoneNumbers
-      requestBody:
-        description: List of phone numbers to create and buy
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/PhoneNumberRequest'
-      responses:
-        200:
-          description: A list of new Twilio phone numbers has been created and bought
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PhoneNumber'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-
-  /phoneNumbers/{id}:
-    get:
-      tags:
-        - Phone Numbers
-      summary: Retrieve phone number details by its ID
-      operationId: getPhoneNumber
-      parameters:
-        - $ref: '#/components/parameters/ResourceId'
-      responses:
-        200:
-          description: The phone number details have been retrieved
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PhoneNumber'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-    put:
-      tags:
-        - Phone Numbers
-      summary: Update a phone number
-      operationId: updatePhoneNumber
-      parameters:
-        - $ref: '#/components/parameters/ResourceId'
-      requestBody:
-        description: Updated phone number specification
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PhoneNumberRequest'
-      responses:
-        200:
-          description: The phone number details have been modified
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PhoneNumber'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-    delete:
-      tags:
-        - Phone Numbers
-      summary: Delete a phone number
-      operationId: deletePhoneNumber
-      parameters:
-        - $ref: '#/components/parameters/ResourceId'
-      responses:
-        200:
-          description: The phone number has been deleted
-          content: { }
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-
-  /users/{id}/phoneNumbers:
-    post:
-      tags:
-        - Phone Numbers
-      summary: Add a phone number and assign it to the user
-      operationId: assignUserPhoneNumber
-      parameters:
-        - $ref: '#/components/parameters/ResourceId'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/Id'
-      responses:
-        201:
-          description: The phone number has been created and assigned to the user
-          content: { }
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-
   /autoReceptionists:
     get:
       tags:
@@ -581,397 +375,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResponseError'
-
-  /calls/callbacks/ivr/{id}:
-    post:
-      tags:
-        - IVR Callbacks
-      x-access: private
-      summary: Callback for doing IVR
-      operationId: numberIVRCallback
-      parameters:
-        - $ref: '#/components/parameters/ResourceId'
-      requestBody:
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              properties:
-                CallSid:
-                  type: string
-                Digits:
-                  type: string
-      responses:
-        200:
-          description: TwiML response has been received
-          content: { }
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-
-  /calls/callbacks/ivr/{id}/noAction/{count}:
-    post:
-      tags:
-        - IVR Callbacks
-      x-access: private
-      summary: Callback for handling when a user enters no action for IVR menu
-      operationId: noActionIVRCallback
-      parameters:
-        - $ref: '#/components/parameters/ResourceId'
-        - name: count
-          description: How many times we play this IVR menu
-          in: path
-          required: true
-          schema:
-            type: integer
-      requestBody:
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              properties:
-                To:
-                  type: string
-                CallSid:
-                  type: string
-      responses:
-        200:
-          description: TwiML response has been received
-          content: { }
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/xml:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-
-  /addresses:
-    get:
-      tags:
-        - Addresses
-      summary: Retrieve addresses
-      operationId: getAddresses
-      parameters:
-        - $ref: '#/components/parameters/QueryPageNumber'
-        - $ref: '#/components/parameters/QueryPageSize'
-        - $ref: '#/components/parameters/QuerySort'
-      responses:
-        200:
-          description: The addresses have been retrieved
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Addresses'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-    post:
-      tags:
-        - Addresses
-      summary: Create a new address for the tenant
-      operationId: createAddress
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AddressRequest'
-      responses:
-        201:
-          description: A new address has been created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Address'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-
-  /regulatoryBundles:
-    get:
-      tags:
-        - Regulatory Bundles
-      x-access: private
-      summary: Retrieve regulatory bundles
-      operationId: getRegulatoryBundles
-      parameters:
-        - name: type
-          in: query
-          description: Filter parameter by "type"
-          schema:
-            type: string
-        - name: status
-          in: query
-          description: Filter parameter by "status"
-          schema:
-            type: string
-        - $ref: '#/components/parameters/QueryPageNumber'
-        - $ref: '#/components/parameters/QueryPageSize'
-        - $ref: '#/components/parameters/QuerySort'
-      responses:
-        200:
-          description: The regulatory bundles have been retrieved
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RegulatoryBundles'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-    post:
-      tags:
-        - Regulatory Bundles
-      x-access: private
-      summary: Create new regulatory bundle
-      operationId: createRegulatoryBundle
-      requestBody:
-        description: Regulation bundle information
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegulatoryBundleRequest'
-        required: true
-      responses:
-        201:
-          description: The regulatory bundle have been created
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RegulatoryBundle'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-  /regulatoryBundles/{id}:
-    get:
-      tags:
-        - Regulatory Bundles
-      x-access: private
-      summary: Retrieve the regulatory bundle by id
-      operationId: getRegulatoryBundle
-      parameters:
-        - $ref: '#/components/parameters/ResourceId'
-      responses:
-        200:
-          description: The regulatory bundle have been retrieved
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RegulatoryBundle'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-    put:
-      tags:
-        - Regulatory Bundles
-      x-access: private
-      summary: Update regulatory bundle by id
-      operationId: updateRegulatoryBundle
-      parameters:
-        - $ref: '#/components/parameters/ResourceId'
-      requestBody:
-        description: Regulation bundle information
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RegulatoryBundleRequest'
-        required: true
-      responses:
-        200:
-          description: The regulatory bundle have been updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RegulatoryBundle'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-    delete:
-      tags:
-        - Regulatory Bundles
-      x-access: private
-      summary: Delete a regulatory bundle by id
-      operationId: deleteRegulatoryBundle
-      parameters:
-        - $ref: '#/components/parameters/ResourceId'
-      responses:
-        204:
-          description: An empty response that is used for OK non-returning operations
-          content: { }
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-  /regulatoryBundles/{id}/sendToReview:
-    post:
-      tags:
-        - Regulatory Bundles
-      x-access: private
-      summary: Send the regulatory bundle to review
-      operationId: sendRegulatoryBundleToReview
-      parameters:
-        - $ref: '#/components/parameters/ResourceId'
-      responses:
-        200:
-          description: The regulatory requirements have been retrieved
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RegulatoryBundle'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-  /regulatoryBundles/requirements:
-    get:
-      tags:
-        - Regulatory Bundles
-      x-access: private
-      summary: Retrieve the list of requirements
-      operationId: getRegulatoryRequirements
-      parameters:
-        - name: countryCode
-          in: query
-          required: true
-          schema:
-            $ref: '#/components/schemas/CountryCode'
-        - name: type
-          in: query
-          required: true
-          description: Phone number type
-          schema:
-            type: string
-      responses:
-        200:
-          description: The regulatory requirements have been retrieved
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RegulatoryBundleRequirements'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-  /regulatoryBundles/callbacks:
-    post:
-      tags:
-        - Regulatory Bundles
-      x-access: private
-      summary: Twilio callback for notify about changes status of regulatory bundle status
-      operationId: regulatoryBundleCallback
-      requestBody:
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              properties:
-                BundleSid:
-                  type: string
-                Status:
-                  type: string
-                FailureReason:
-                  type: string
-      responses:
-        204:
-          description: An empty response that is used for OK non-returning operations
-          content: { }
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-
-  /reports:
-    get:
-      tags:
-        - Reports
-      summary: Retrieve a list of available reports.
-      operationId: getReports
-      parameters:
-        - $ref: '#/components/parameters/QueryPageNumber'
-        - $ref: '#/components/parameters/QueryPageSize'
-        - $ref: '#/components/parameters/QuerySort'
-      responses:
-        200:
-          description: The list of reports has been retrieved
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Reports'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-
-  /reports/{id}/data:
-    get:
-      tags:
-        - Report Data
-      summary: Gets data of the specific report.
-      operationId: getReportData
-      parameters:
-        - $ref: '#/components/parameters/ResourceId'
-        - name: from
-          in: query
-          required: true
-          description: The date when the report data set calculation starts
-          schema:
-            type: integer
-            format: int64
-        - name: to
-          in: query
-          required: true
-          description: The date when the report data set calculation starts
-          schema:
-            type: integer
-            format: int64
-        - name: who
-          in: query
-          description: The report can show data for the currently authenticated user (ME) or the whole team (TEAM).
-          schema:
-            type: string
-            enum:
-              - ME
-              - TEAM
-      responses:
-        200:
-          description: The data of the report.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ReportData'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-
   /calls:
     get:
       tags:
@@ -1254,78 +657,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CallParticipant'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-
-  /participants/{id}:
-    patch:
-      tags:
-        - Participants
-      summary: Update participant
-      operationId: patchParticipant
-      parameters:
-        - $ref: '#/components/parameters/ResourceId'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ParticipantChangeRequestBody'
-        required: false
-      responses:
-        200:
-          description: The participant has been updated
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CallParticipant'
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-    delete:
-      tags:
-        - Participants
-      summary: Delete participant from conference
-      operationId: removeParticipant
-      parameters:
-        - $ref: '#/components/parameters/ResourceId'
-      responses:
-        204:
-          description: The participant has been deleted
-        default:
-          description: Bad request, security violation, or internal server error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResponseError'
-  /participants:
-    patch:
-      tags:
-        - Participants
-      summary: Update list of participants
-      operationId: patchParticipants
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/ParticipantChangeRequest'
-      responses:
-        200:
-          description: The updated participants have been retreived
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/CallParticipant'
         default:
           description: Bad request, security violation, or internal server error
           content:
@@ -1618,7 +949,6 @@ paths:
             application/xml:
               schema:
                 $ref: '#/components/schemas/ResponseError'
-
   /calls/callbacks/{id}/status/{participantId}:
     post:
       tags:
@@ -1688,7 +1018,68 @@ paths:
             application/xml:
               schema:
                 $ref: '#/components/schemas/ResponseError'
-
+  /calls/callbacks/ivr/{id}:
+    post:
+      tags:
+        - IVR Callbacks
+      x-access: private
+      summary: Callback for doing IVR
+      operationId: numberIVRCallback
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                CallSid:
+                  type: string
+                Digits:
+                  type: string
+      responses:
+        200:
+          description: TwiML response has been received
+          content: { }
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /calls/callbacks/ivr/{id}/noAction/{count}:
+    post:
+      tags:
+        - IVR Callbacks
+      x-access: private
+      summary: Callback for handling when a user enters no action for IVR menu
+      operationId: noActionIVRCallback
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+        - name: count
+          description: How many times we play this IVR menu
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                To:
+                  type: string
+                CallSid:
+                  type: string
+      responses:
+        200:
+          description: TwiML response has been received
+          content: { }
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
   /contacts:
     get:
       tags:
@@ -1804,67 +1195,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResponseError'
-
-  /voicemails:
+  /health:
     get:
       tags:
-        - Voicemails
-      summary: Retrieve the voicemails
-      operationId: getVoicemails
-      parameters:
-        - $ref: '#/components/parameters/QueryPageNumber'
-        - $ref: '#/components/parameters/QueryPageSize'
-        - $ref: '#/components/parameters/QuerySort'
-        - name: phoneNumberId
-          in: query
-          schema:
-            type: string
-        - name: autoReceptionistId
-          in: query
-          schema:
-            type: string
-        - name: userId
-          in: query
-          schema:
-            type: string
-        - name: state
-          in: query
-          schema:
-            type: string
+        - Health Checks
+      summary: Check the health of the microservice
+      operationId: checkHealth
       responses:
         200:
-          description: The voicemail contents have been retrieved
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Recordings'
+          description: An empty response that is used for OK non-returning operations
+          content: { }
         default:
           description: Bad request, security violation, or internal server error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResponseError'
-
-  /voicemails/{id}:
+  /participants/{id}:
     patch:
       tags:
-        - Voicemails
-      summary: Update (partially) the voicemail
-      operationId: updateVoicemail
+        - Participants
+      summary: Update participant
+      operationId: patchParticipant
       parameters:
         - $ref: '#/components/parameters/ResourceId'
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RecordingRequest'
+              $ref: '#/components/schemas/ParticipantChangeRequestBody'
+        required: false
       responses:
         200:
-          description: The voicemail has been updated
+          description: The participant has been updated
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Recording'
+                $ref: '#/components/schemas/CallParticipant'
         default:
           description: Bad request, security violation, or internal server error
           content:
@@ -1873,14 +1240,185 @@ paths:
                 $ref: '#/components/schemas/ResponseError'
     delete:
       tags:
-        - Voicemails
-      summary: Delete a voicemail
-      operationId: deleteVoicemail
+        - Participants
+      summary: Delete participant from conference
+      operationId: removeParticipant
       parameters:
         - $ref: '#/components/parameters/ResourceId'
       responses:
         204:
-          description: The voicemail has been deleted
+          description: The participant has been deleted
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /participants:
+    patch:
+      tags:
+        - Participants
+      summary: Update list of participants
+      operationId: patchParticipants
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/ParticipantChangeRequest'
+      responses:
+        200:
+          description: The updated participants have been retreived
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CallParticipant'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /phoneNumbers:
+    get:
+      tags:
+        - Phone Numbers
+      summary: Retrieve a list of phone numbers
+      operationId: getPhoneNumbers
+      parameters:
+        - name: userId
+          in: query
+          description: Filter by the user assignment
+          schema:
+            type: string
+            example: eq::fda3787b-9f4e-45e3-91a3-46d61003c2d7
+        - name: assignmentType
+          in: query
+          description: Filter by the assignment type
+          schema:
+            type: string
+            example: eq::USER
+        - name: number
+          in: query
+          description: Search parameters by the phone number
+          schema:
+            minLength: 3
+            type: string
+        - name: type
+          in: query
+          description: Filter by the phone number type
+          schema:
+            type: string
+            example: eq::LOCAL
+        - name: regulatoryStatus
+          in: query
+          description: Filter by the status of the phone number's regulatory bundle
+          schema:
+            type: string
+        - $ref: '#/components/parameters/QueryPageNumber'
+        - $ref: '#/components/parameters/QueryPageSize'
+        - $ref: '#/components/parameters/QuerySort'
+      responses:
+        200:
+          description: The phone numbers have been retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PhoneNumbers'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+    post:
+      tags:
+        - Phone Numbers
+      summary: Buy and create a list of Twilio phone numbers
+      operationId: buyPhoneNumbers
+      requestBody:
+        description: List of phone numbers to create and buy
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/PhoneNumberRequest'
+      responses:
+        200:
+          description: A list of new Twilio phone numbers has been created and bought
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PhoneNumber'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /phoneNumbers/{id}:
+    get:
+      tags:
+        - Phone Numbers
+      summary: Retrieve phone number details by its ID
+      operationId: getPhoneNumber
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      responses:
+        200:
+          description: The phone number details have been retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PhoneNumber'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+    put:
+      tags:
+        - Phone Numbers
+      summary: Update a phone number
+      operationId: updatePhoneNumber
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      requestBody:
+        description: Updated phone number specification
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PhoneNumberRequest'
+      responses:
+        200:
+          description: The phone number details have been modified
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PhoneNumber'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+    delete:
+      tags:
+        - Phone Numbers
+      summary: Delete a phone number
+      operationId: deletePhoneNumber
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      responses:
+        200:
+          description: The phone number has been deleted
           content: { }
         default:
           description: Bad request, security violation, or internal server error
@@ -1888,7 +1426,369 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResponseError'
-
+  /regulatoryBundles:
+    get:
+      tags:
+        - Regulatory Bundles
+      x-access: private
+      summary: Retrieve regulatory bundles
+      operationId: getRegulatoryBundles
+      parameters:
+        - name: type
+          in: query
+          description: Filter parameter by "type"
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Filter parameter by "status"
+          schema:
+            type: string
+        - $ref: '#/components/parameters/QueryPageNumber'
+        - $ref: '#/components/parameters/QueryPageSize'
+        - $ref: '#/components/parameters/QuerySort'
+      responses:
+        200:
+          description: The regulatory bundles have been retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegulatoryBundles'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+    post:
+      tags:
+        - Regulatory Bundles
+      x-access: private
+      summary: Create new regulatory bundle
+      operationId: createRegulatoryBundle
+      requestBody:
+        description: Regulation bundle information
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegulatoryBundleRequest'
+        required: true
+      responses:
+        201:
+          description: The regulatory bundle have been created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegulatoryBundle'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /regulatoryBundles/{id}:
+    get:
+      tags:
+        - Regulatory Bundles
+      x-access: private
+      summary: Retrieve the regulatory bundle by id
+      operationId: getRegulatoryBundle
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      responses:
+        200:
+          description: The regulatory bundle have been retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegulatoryBundle'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+    put:
+      tags:
+        - Regulatory Bundles
+      x-access: private
+      summary: Update regulatory bundle by id
+      operationId: updateRegulatoryBundle
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      requestBody:
+        description: Regulation bundle information
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegulatoryBundleRequest'
+        required: true
+      responses:
+        200:
+          description: The regulatory bundle have been updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegulatoryBundle'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+    delete:
+      tags:
+        - Regulatory Bundles
+      x-access: private
+      summary: Delete a regulatory bundle by id
+      operationId: deleteRegulatoryBundle
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      responses:
+        204:
+          description: An empty response that is used for OK non-returning operations
+          content: { }
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /regulatoryBundles/{id}/sendToReview:
+    post:
+      tags:
+        - Regulatory Bundles
+      x-access: private
+      summary: Send the regulatory bundle to review
+      operationId: sendRegulatoryBundleToReview
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      responses:
+        200:
+          description: The regulatory requirements have been retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegulatoryBundle'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /regulatoryBundles/requirements:
+    get:
+      tags:
+        - Regulatory Bundles
+      x-access: private
+      summary: Retrieve the list of requirements
+      operationId: getRegulatoryRequirements
+      parameters:
+        - name: countryCode
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/CountryCode'
+        - name: type
+          in: query
+          required: true
+          description: Phone number type
+          schema:
+            type: string
+      responses:
+        200:
+          description: The regulatory requirements have been retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegulatoryBundleRequirements'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /regulatoryBundles/callbacks:
+    post:
+      tags:
+        - Regulatory Bundles
+      x-access: private
+      summary: Twilio callback for notify about changes status of regulatory bundle status
+      operationId: regulatoryBundleCallback
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                BundleSid:
+                  type: string
+                Status:
+                  type: string
+                FailureReason:
+                  type: string
+      responses:
+        204:
+          description: An empty response that is used for OK non-returning operations
+          content: { }
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /reports:
+    get:
+      tags:
+        - Reports
+      summary: Retrieve a list of available reports.
+      operationId: getReports
+      parameters:
+        - $ref: '#/components/parameters/QueryPageNumber'
+        - $ref: '#/components/parameters/QueryPageSize'
+        - $ref: '#/components/parameters/QuerySort'
+      responses:
+        200:
+          description: The list of reports has been retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reports'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /reports/{id}/data:
+    get:
+      tags:
+        - Report Data
+      summary: Gets data of the specific report.
+      operationId: getReportData
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+        - name: from
+          in: query
+          required: true
+          description: The date when the report data set calculation starts
+          schema:
+            type: integer
+            format: int64
+        - name: to
+          in: query
+          required: true
+          description: The date when the report data set calculation starts
+          schema:
+            type: integer
+            format: int64
+        - name: who
+          in: query
+          description: The report can show data for the currently authenticated user (ME) or the whole team (TEAM).
+          schema:
+            type: string
+            enum:
+              - ME
+              - TEAM
+      responses:
+        200:
+          description: The data of the report.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportData'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /services/textToSpeech:
+    post:
+      tags:
+        - Services
+      summary: Convert text into audio
+      operationId: textToSpeech
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TextToSpeechRequest'
+      responses:
+        200:
+          description: The synthesized audio
+          content:
+            audio/*:
+              schema:
+                type: string
+                format: binary
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            audio/*:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /services/phoneNumbersToBuy:
+    get:
+      tags:
+        - Services
+      summary: Retrieve a list of available phone numbers from Twilio
+      operationId: findPhoneNumbersAvailableToBuy
+      parameters:
+        - name: countryCode
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/CountryCode'
+        - name: areaCode
+          in: query
+          description: The rate center of the phone number
+          schema:
+            type: string
+        - name: type
+          in: query
+          description: Filter phone numbers by type
+          schema:
+            $ref: '#/components/schemas/PhoneNumberType'
+      responses:
+        200:
+          description: The list of phone numbers has been retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AvailablePhoneNumber'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /users/{id}/phoneNumbers:
+    post:
+      tags:
+        - Phone Numbers
+      summary: Add a phone number and assign it to the user
+      operationId: assignUserPhoneNumber
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Id'
+      responses:
+        201:
+          description: The phone number has been created and assigned to the user
+          content: { }
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
   /userSettings:
     get:
       tags:
@@ -1932,7 +1832,88 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResponseError'
-
+  /voicemails:
+    get:
+      tags:
+        - Voicemails
+      summary: Retrieve the voicemails
+      operationId: getVoicemails
+      parameters:
+        - $ref: '#/components/parameters/QueryPageNumber'
+        - $ref: '#/components/parameters/QueryPageSize'
+        - $ref: '#/components/parameters/QuerySort'
+        - name: phoneNumberId
+          in: query
+          schema:
+            type: string
+        - name: autoReceptionistId
+          in: query
+          schema:
+            type: string
+        - name: userId
+          in: query
+          schema:
+            type: string
+        - name: state
+          in: query
+          schema:
+            type: string
+      responses:
+        200:
+          description: The voicemail contents have been retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Recordings'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+  /voicemails/{id}:
+    patch:
+      tags:
+        - Voicemails
+      summary: Update (partially) the voicemail
+      operationId: updateVoicemail
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecordingRequest'
+      responses:
+        200:
+          description: The voicemail has been updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Recording'
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+    delete:
+      tags:
+        - Voicemails
+      summary: Delete a voicemail
+      operationId: deleteVoicemail
+      parameters:
+        - $ref: '#/components/parameters/ResourceId'
+      responses:
+        204:
+          description: The voicemail has been deleted
+          content: { }
+        default:
+          description: Bad request, security violation, or internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
   /widgets:
     get:
       tags:
@@ -1975,6 +1956,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ResponseError'
+
 components:
 
   securitySchemes:

--- a/talk/talk-api.yaml
+++ b/talk/talk-api.yaml
@@ -16,41 +16,58 @@ security:
 
 tags:
   - name: Addresses
-    description:
+    description: |
+      To ensure the billing is correct, the tenants should maintain a valid address in the Inperium Talk settings.
   - name: Audio Files
-    description:
+    description: |
+      Inperium Talk enables you to create an audio library with custom recordings that you can leverage in auto receptionists and IVR menues.
   - name: Auto Receptionists
-    description:
+    description: |
+      Auto receptionists streamline call routing both during work hours and off-duty. An auto receptionist represents an automatic workflow and consists of configurable rules and steps. For example, you set a greeting audio and then enable an IVR menu that helps forward the call to the right manager. Auto receptionists can be multi-tiered and reference each other.
   - name: Calls
-    description:
+    description: |
+      Inperium Talk enables users to make calls and logs all statictics about them such as the duration of the call, the direction of call (inbound, outbound), and call particiapants.
   - name: Call Callbacks
-    description:
+    description: |
+      We use callbacks from our partnner & service provider to manage calls within Inperium Talk system.
   - name: Contacts
-    description:
+    description: |
+      Add your clients and business partners to the Contacts list. The Contacts store information such as a name, work and personal phone numbers, and address.
   - name: Health Checks
-    description:
+    description: |
+      Since Inperium runs multiple services under the hood, it's crucial to identify the health state of each service. You can rely on the health state information when troubleshooting issues.
   - name: IVR Callbacks
-    description:
+    description: |
+      IVR menu is a simple and interactive routing system. You can configure an action for each digit. The callbacks help manage user inputs.
   - name: Participants
-    description:
+    description: |
+      Each call has multiple participants—persons taking part in the call either as a caller or as recipients.
   - name: Phone Numbers
-    description:
+    description: |
+      Inperium Talk enables users to create VoIP phone numbers and leverage them for making calls and sending mesages.
   - name: Recording Callbacks
-    description:
+    description: |
+      Inperium Talk enables you to create recordings.
   - name: Regulatory Bundles
-    description:
+    description: |
+      Depeding on your location and various usage options, you might be subject to taxes and fees. These taxes will be added to your bill.
   - name: Reports
-    description:
+    description: |
+      Inperium Talk creates reports to help you assess productivity and see how your metrics change over time.
   - name: Report Data
-    description:
+    description: |
+      The report data is the actual metrics and values.
   - name: Services
-    description:
+    description: |
+      Inperium Talk provides various communication services such as the ability to generate voice recordings based on text or buy phone numbers from our partners.
   - name: Voicemails
-    description:
+    description: |
+      The voicemails are the messages the clients leave when nobody picks the line. It's a safe and reliable way to gather inquires when your managers are out of office.
   - name: User Settings
-    description:
+    description: |
+      Each user has a unique profile that contains information about the default contact number, forwarding options, and many more.
   - name: Widgets
-    description:
+    description: In Inperium Talk, widgets are dashboard elements such as charts and lists that help track your productivity.
 
 paths:
   /health:

--- a/talk/talk-api.yaml
+++ b/talk/talk-api.yaml
@@ -89,7 +89,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Addresses'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -112,7 +112,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Address'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -141,7 +141,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AudioFiles'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -164,7 +164,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AudioFile'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -185,7 +185,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AudioFile'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -202,7 +202,7 @@ paths:
           description: The audio file has been deleted
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -227,7 +227,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AudioFile'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -256,7 +256,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AutoReceptionists'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -280,7 +280,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AutoReceptionist'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -301,7 +301,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AutoReceptionist'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -327,7 +327,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AutoReceptionist'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -353,7 +353,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AutoReceptionist'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -370,7 +370,7 @@ paths:
           description: The auto receptionist has been deleted
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -464,7 +464,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Calls'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -487,7 +487,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Call'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -512,7 +512,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Call'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -541,7 +541,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/VoiceToken'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -562,7 +562,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Call'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -588,7 +588,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Call'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -614,7 +614,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Call'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -628,10 +628,10 @@ paths:
         - $ref: '#/components/parameters/ResourceId'
       responses:
         204:
-          description: An empty response that is used for OK non-returning operations
+          description: Returns an empty response.
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -658,7 +658,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CallParticipant'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -692,7 +692,7 @@ paths:
           description: TwiML response has been received
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/xml:
               schema:
@@ -720,7 +720,7 @@ paths:
           description: TwiML response has been received
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/xml:
               schema:
@@ -750,7 +750,7 @@ paths:
           description: TwiML response has been received
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/xml:
               schema:
@@ -783,7 +783,7 @@ paths:
           description: TwiML response has been received
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/xml:
               schema:
@@ -815,7 +815,7 @@ paths:
           description: The status has been accepted
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -845,7 +845,7 @@ paths:
           description: TwiML response has been received
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/xml:
               schema:
@@ -871,7 +871,7 @@ paths:
           description: TwiML response has been received
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/xml:
               schema:
@@ -902,7 +902,7 @@ paths:
           description: TwiML response has been received
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/xml:
               schema:
@@ -944,7 +944,7 @@ paths:
           description: TwiML response has been received
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/xml:
               schema:
@@ -984,7 +984,7 @@ paths:
           description: TwiML response has been received
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/xml:
               schema:
@@ -1013,7 +1013,7 @@ paths:
           description: Empty response has been received
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/xml:
               schema:
@@ -1041,7 +1041,7 @@ paths:
           description: TwiML response has been received
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/xml:
               schema:
@@ -1075,7 +1075,7 @@ paths:
           description: TwiML response has been received
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/xml:
               schema:
@@ -1102,7 +1102,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Contacts'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1126,7 +1126,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Contact'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1147,7 +1147,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Contact'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1173,7 +1173,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Contact'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1190,7 +1190,7 @@ paths:
           description: The contact has been deleted
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1203,10 +1203,10 @@ paths:
       operationId: checkHealth
       responses:
         200:
-          description: An empty response that is used for OK non-returning operations
+          description: Returns an empty response.
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1233,7 +1233,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CallParticipant'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1249,7 +1249,7 @@ paths:
         204:
           description: The participant has been deleted
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1277,7 +1277,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/CallParticipant'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1329,7 +1329,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PhoneNumbers'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1357,7 +1357,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/PhoneNumber'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1378,7 +1378,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PhoneNumber'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1404,7 +1404,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PhoneNumber'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1421,7 +1421,7 @@ paths:
           description: The phone number has been deleted
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1455,7 +1455,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/RegulatoryBundles'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1481,7 +1481,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/RegulatoryBundle'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1503,7 +1503,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/RegulatoryBundle'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1531,7 +1531,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/RegulatoryBundle'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1546,10 +1546,10 @@ paths:
         - $ref: '#/components/parameters/ResourceId'
       responses:
         204:
-          description: An empty response that is used for OK non-returning operations
+          description: Returns an empty response.
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1571,7 +1571,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/RegulatoryBundle'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1603,7 +1603,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/RegulatoryBundleRequirements'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1628,10 +1628,10 @@ paths:
                   type: string
       responses:
         204:
-          description: An empty response that is used for OK non-returning operations
+          description: Returns an empty response.
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1654,7 +1654,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Reports'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1697,7 +1697,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReportData'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1722,7 +1722,7 @@ paths:
                 type: string
                 format: binary
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             audio/*:
               schema:
@@ -1759,7 +1759,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/AvailablePhoneNumber'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1784,7 +1784,7 @@ paths:
           description: The phone number has been created and assigned to the user
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1803,7 +1803,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserSettings'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1827,7 +1827,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserSettings'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1866,7 +1866,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Recordings'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1892,7 +1892,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Recording'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1909,7 +1909,7 @@ paths:
           description: The voicemail has been deleted
           content: { }
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:
@@ -1951,7 +1951,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Widgets'
         default:
-          description: Bad request, security violation, or internal server error
+          description: Bad request, security violation, or internal server error.
           content:
             application/json:
               schema:

--- a/talk/talk-api.yaml
+++ b/talk/talk-api.yaml
@@ -586,6 +586,7 @@ paths:
     post:
       tags:
         - IVR Callbacks
+      x-access: private
       summary: Callback for doing IVR
       operationId: numberIVRCallback
       parameters:
@@ -614,6 +615,7 @@ paths:
     post:
       tags:
         - IVR Callbacks
+      x-access: private
       summary: Callback for handling when a user enters no action for IVR menu
       operationId: noActionIVRCallback
       parameters:
@@ -695,6 +697,7 @@ paths:
     get:
       tags:
         - Regulatory Bundles
+      x-access: private
       summary: Retrieve regulatory bundles
       operationId: getRegulatoryBundles
       parameters:
@@ -727,6 +730,7 @@ paths:
     post:
       tags:
         - Regulatory Bundles
+      x-access: private
       summary: Create new regulatory bundle
       operationId: createRegulatoryBundle
       requestBody:
@@ -753,6 +757,7 @@ paths:
     get:
       tags:
         - Regulatory Bundles
+      x-access: private
       summary: Retrieve the regulatory bundle by id
       operationId: getRegulatoryBundle
       parameters:
@@ -773,6 +778,7 @@ paths:
     put:
       tags:
         - Regulatory Bundles
+      x-access: private
       summary: Update regulatory bundle by id
       operationId: updateRegulatoryBundle
       parameters:
@@ -799,7 +805,8 @@ paths:
                 $ref: '#/components/schemas/ResponseError'
     delete:
       tags:
-        - Regulatory bundles
+        - Regulatory Bundles
+      x-access: private
       summary: Delete a regulatory bundle by id
       operationId: deleteRegulatoryBundle
       parameters:
@@ -817,7 +824,8 @@ paths:
   /regulatoryBundles/{id}/sendToReview:
     post:
       tags:
-        - Regulatory bundles
+        - Regulatory Bundles
+      x-access: private
       summary: Send the regulatory bundle to review
       operationId: sendRegulatoryBundleToReview
       parameters:
@@ -838,7 +846,8 @@ paths:
   /regulatoryBundles/requirements:
     get:
       tags:
-        - Regulatory bundles
+        - Regulatory Bundles
+      x-access: private
       summary: Retrieve the list of requirements
       operationId: getRegulatoryRequirements
       parameters:
@@ -869,7 +878,8 @@ paths:
   /regulatoryBundles/callbacks:
     post:
       tags:
-        - Regulatory bundles
+        - Regulatory Bundles
+      x-access: private
       summary: Twilio callback for notify about changes status of regulatory bundle status
       operationId: regulatoryBundleCallback
       requestBody:
@@ -1326,6 +1336,7 @@ paths:
     post:
       tags:
         - Call Callbacks
+      x-access: private
       summary: Twilio callback for call conference
       operationId: conferenceCallback
       parameters:
@@ -1359,6 +1370,7 @@ paths:
     post:
       tags:
         - Call Callbacks
+      x-access: private
       summary: Add a fallback URL in case of error during the call
       operationId: fallbackCall
       requestBody:
@@ -1386,6 +1398,7 @@ paths:
     post:
       tags:
         - Call Callbacks
+      x-access: private
       summary: Notify about new inbound call on Twilio number
       operationId: startInboundCall
       requestBody:
@@ -1415,6 +1428,7 @@ paths:
     post:
       tags:
         - Call Callbacks
+      x-access: private
       summary: Notify about the start of outbound Twilio call
       operationId: startOutboundCall
       requestBody:
@@ -1447,6 +1461,7 @@ paths:
     post:
       tags:
         - Call Callbacks
+      x-access: private
       summary: Set the status of the current Twilio call
       operationId: setCallStatus
       requestBody:
@@ -1478,6 +1493,7 @@ paths:
     post:
       tags:
         - Call Callbacks
+      x-access: private
       summary: Forward the incoming call if the agent does not answer in the browser
       operationId: forwardIncomingCall
       parameters:
@@ -1507,6 +1523,7 @@ paths:
     post:
       tags:
         - Call Callbacks
+      x-access: private
       summary: Twilio callback for call client on app
       operationId: joinUserToCall
       parameters:
@@ -1532,6 +1549,7 @@ paths:
     post:
       tags:
         - Recording Callbacks
+      x-access: private
       summary: Instruct Twilio to make a POST request when the recording has finished
       operationId: saveRecording
       parameters:
@@ -1562,6 +1580,7 @@ paths:
     post:
       tags:
         - Recording Callbacks
+      x-access: private
       summary: Instruct Twilio to make a POST request when the recording has finished
       operationId: saveRecordingWithType
       parameters:
@@ -1604,6 +1623,7 @@ paths:
     post:
       tags:
         - Call Callbacks
+      x-access: private
       summary: Twilio callback for status call
       operationId: callStatus
       parameters:
@@ -1643,6 +1663,7 @@ paths:
     post:
       tags:
         - Recording Callbacks
+      x-access: private
       summary: Instruct Twilio to make an asynchronous POST request when the transcription
         for recording is complete
       operationId: saveRecordingMessage

--- a/talk/talk-api.yaml
+++ b/talk/talk-api.yaml
@@ -75,7 +75,8 @@ paths:
     get:
       tags:
         - Addresses
-      summary: Retrieve addresses
+      summary: List addresses
+      description: Use this endpoint to retrieve addresses. This request supports paging and sorting.
       operationId: getAddresses
       parameters:
         - $ref: '#/components/parameters/QueryPageNumber'
@@ -83,7 +84,7 @@ paths:
         - $ref: '#/components/parameters/QuerySort'
       responses:
         200:
-          description: The addresses have been retrieved
+          description: The addresses have been retrieved. Returns addresses.
           content:
             application/json:
               schema:
@@ -97,16 +98,18 @@ paths:
     post:
       tags:
         - Addresses
-      summary: Create a new address for the tenant
+      summary: Create an address.
+      description: Use this endpoint to add a new address for a tenant.
       operationId: createAddress
       requestBody:
+        description: In the request body, pass the AddressRequest object.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AddressRequest'
       responses:
         201:
-          description: A new address has been created
+          description: The address has been created. Returns the address.
           content:
             application/json:
               schema:
@@ -121,7 +124,8 @@ paths:
     get:
       tags:
         - Audio Files
-      summary: Get list of audio files
+      summary: List audio files
+      description: Use this endpoint to retrieve a list of available audio files stored in the Audio Library. This request supports paging, sorting, and filtering.
       operationId: getAudioFiles
       parameters:
         - $ref: '#/components/parameters/QueryPageNumber'
@@ -129,13 +133,12 @@ paths:
         - $ref: '#/components/parameters/QuerySort'
         - name: name
           in: query
-          description: Filter by name
+          description: The name of the audio file.
           schema:
             type: string
-            example: like::Some name
       responses:
         200:
-          description: The list of audio files have been retrieved
+          description: The list of audio files has been retrieved. Returns audio files.
           content:
             application/json:
               schema:
@@ -149,16 +152,18 @@ paths:
     post:
       tags:
         - Audio Files
-      summary: Upload a new audio file
+      summary: Add an audio file
+      description: Use this endpoint to upload a new audio file.
       operationId: uploadAudioFile
       requestBody:
+        description: In the request body, pass the AudioFileUploadRequest object.
         content:
           multipart/form-data:
             schema:
               $ref: '#/components/schemas/AudioFileUploadRequest'
       responses:
         201:
-          description: The audio file have been created
+          description: The audio file has been created. Returns an audio file.
           content:
             application/json:
               schema:
@@ -173,13 +178,14 @@ paths:
     get:
       tags:
         - Audio Files
-      summary: Retrieve audio file details by its ID
+      summary: Get audio file by ID
+      description: Use this endpoint to retrieve details on specific audio file based on its ID.
       operationId: getAudioFile
       parameters:
         - $ref: '#/components/parameters/ResourceId'
       responses:
         200:
-          description: The audio file details have been retrieved
+          description: The audio file details have been retrieved. Returns an audio file details.
           content:
             application/json:
               schema:
@@ -193,13 +199,14 @@ paths:
     delete:
       tags:
         - Audio Files
-      summary: Delete the audio file
+      summary: Delete an audio file
+      description: Use this endpoint to remove an audio file.
       operationId: deleteAudioFile
       parameters:
         - $ref: '#/components/parameters/ResourceId'
       responses:
         200:
-          description: The audio file has been deleted
+          description: The audio file has been deleted.
           content: { }
         default:
           description: Bad request, security violation, or internal server error.
@@ -210,18 +217,20 @@ paths:
     patch:
       tags:
         - Audio Files
-      summary: Update (partially) the audio file
+      summary: Partially update an audio file
+      description: Use this endpoint to partially update the audio file details.
       operationId: updateAudioFile
       parameters:
         - $ref: '#/components/parameters/ResourceId'
       requestBody:
+        description: In the request body, pass the updated AudioFileUpdateRequest object.
         content:
           multipart/form-data:
             schema:
               $ref: '#/components/schemas/AudioFileUpdateRequest'
       responses:
         200:
-          description: The audio file has been updated
+          description: The audio file has been updated. Returns the audio file.
           content:
             application/json:
               schema:
@@ -236,21 +245,22 @@ paths:
     get:
       tags:
         - Auto Receptionists
-      summary: Retrieve a list of auto receptionists.
+      summary: List auto receptionists
+      description: Use this endpoint to retrieve a list of auto receptionists configured for this tenant. The request support paging, sorting, and filtering.
       operationId: findAutoReceptionists
       parameters:
         - name: name
           in: query
-          description: Filter by name
+          description: The auto receptionist name.
           schema:
             type: string
-            example: like::Some name
+            example: like::Departments
         - $ref: '#/components/parameters/QueryPageNumber'
         - $ref: '#/components/parameters/QueryPageSize'
         - $ref: '#/components/parameters/QuerySort'
       responses:
         200:
-          description: The auto receptionists have been retrieved
+          description: The auto receptionists have been retrieved. Returns auto receptionists.
           content:
             application/json:
               schema:
@@ -264,17 +274,18 @@ paths:
     post:
       tags:
         - Auto Receptionists
-      summary: Create a new auto receptionist
+      summary: Create an auto receptionist
+      description: Use this endpoint to configure a new auto receptionist.
       operationId: createAutoReceptionist
       requestBody:
-        description: Auto receptionist to create
+        description: In the request body, pass the AutoReceptionistRequest object.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AutoReceptionistRequest'
       responses:
         201:
-          description: A new auto receptionist has been created
+          description: A new auto receptionist has been created. Returns an auto receptionist.
           content:
             application/json:
               schema:
@@ -289,13 +300,14 @@ paths:
     get:
       tags:
         - Auto Receptionists
-      summary: Retrieve details of the auto receptionist by its ID
+      summary: Retrieve an auto receptionist
+      description: Use this endpoint to retrieve details for a specific auto receptionist by its ID.
       operationId: findAutoReceptionist
       parameters:
         - $ref: '#/components/parameters/ResourceId'
       responses:
         200:
-          description: The details of the auto receptionist have been retrieved
+          description: The auto receptionist details have been retrieved. Returns an auto receptionist.
           content:
             application/json:
               schema:
@@ -310,18 +322,19 @@ paths:
       tags:
         - Auto Receptionists
       summary: Partially update an auto receptionist
+      description: Use this endpoint to partially modify an existing auto receptionist.
       operationId: partiallyUpdateAutoReceptionist
       parameters:
         - $ref: '#/components/parameters/ResourceId'
       requestBody:
-        description: Partially updated auto receptionist specification
+        description: In the request body, pass the updated AutoReceptionistRequest object.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AutoReceptionistRequest'
       responses:
         200:
-          description: The auto receptionist has been modified
+          description: The auto receptionist has been modified. Returns an auto receptionist.
           content:
             application/json:
               schema:
@@ -336,18 +349,19 @@ paths:
       tags:
         - Auto Receptionists
       summary: Update an auto receptionist
+      description: Use this endpoint to completely overwrite the current auto receptionist settings.
       operationId: updateAutoReceptionist
       parameters:
         - $ref: '#/components/parameters/ResourceId'
       requestBody:
-        description: Updated auto receptionist specification
+        description: In the request body, pass the updated AutoReceptionistRequest object.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/AutoReceptionistRequest'
       responses:
         200:
-          description: The auto receptionist has been modified
+          description: The auto receptionist has been modified. Returns the auto receptionist.
           content:
             application/json:
               schema:
@@ -362,12 +376,13 @@ paths:
       tags:
         - Auto Receptionists
       summary: Delete an auto receptionist
+      description: Use this endpoint to remove an auto receptionist.
       operationId: deleteAutoReceptionist
       parameters:
         - $ref: '#/components/parameters/ResourceId'
       responses:
         204:
-          description: The auto receptionist has been deleted
+          description: The auto receptionist has been deleted.
           content: { }
         default:
           description: Bad request, security violation, or internal server error.


### PR DESCRIPTION
This is an initial PR with the Talk service descriptions. I think it makes sense to merge it to the development branch earlier since it changes the order of the endpoints and it's better to avoid bothersome merging. 

What has changed:
- added the tags section, listed all tags, added descriptions for them
- assigned the x-access: private label to /regulatoryBundles and all callback endpoints
- updated error response texts
- sorted endpoints in the alphabet order