### PR TITLE
IBA-119: Add TryOutToolActivityRequest

### DIFF
--- a/lead-router/lead-router-api.yaml
+++ b/lead-router/lead-router-api.yaml
@@ -128,8 +128,8 @@ components:
           EMAIL_VERIFIED: "#/components/schemas/EmailVerificationActivityRequest"
           contacted_us: "#/components/schemas/ContactUsActivityRequest"
           CONTACTED_US: "#/components/schemas/ContactUsActivityRequest"
-          tool_tried_out: "#/components/schemas/TryOutToolActivityRequest"
-          TOOL_TRIED_OUT: "#/components/schemas/TryOutToolActivityRequest"
+          free_tool_used: "#/components/schemas/FreeToolActivityRequest"
+          FREE_TOOL_USED: "#/components/schemas/FreeToolActivityRequest"
       properties:
         lastReferrerUrl:
           type: string
@@ -365,7 +365,7 @@ components:
               type: string
               description: The message text submitted by the lead.
 
-    TryOutToolActivityRequest:
+    FreeToolActivityRequest:
       type: object
       description: The request model to log an activity for a lead that tried out a free tool.
       allOf:
@@ -374,7 +374,6 @@ components:
           required:
             - email
             - firstName
-            - lastName
             - toolName
           properties:
             email:
@@ -388,4 +387,4 @@ components:
               description: The lead's family name.
             toolName:
               type: string
-              description: The tool tried out by the lead.
+              description: The tool used by the lead.

--- a/lead-router/lead-router-api.yaml
+++ b/lead-router/lead-router-api.yaml
@@ -128,6 +128,8 @@ components:
           EMAIL_VERIFIED: "#/components/schemas/EmailVerificationActivityRequest"
           contacted_us: "#/components/schemas/ContactUsActivityRequest"
           CONTACTED_US: "#/components/schemas/ContactUsActivityRequest"
+          tool_tried_out: "#/components/schemas/TryOutToolActivityRequest"
+          TOOL_TRIED_OUT: "#/components/schemas/TryOutToolActivityRequest"
       properties:
         lastReferrerUrl:
           type: string
@@ -362,3 +364,28 @@ components:
             message:
               type: string
               description: The message text submitted by the lead.
+
+    TryOutToolActivityRequest:
+      type: object
+      description: The request model to log an activity for a lead that tried out a free tool.
+      allOf:
+        - $ref: "#/components/schemas/ActivityRequest"
+        - type: object
+          required:
+            - email
+            - firstName
+            - lastName
+            - toolName
+          properties:
+            email:
+              type: string
+              description: The lead's email address.
+            firstName:
+              type: string
+              description: The lead's given name.
+            lastName:
+              type: string
+              description: The lead's family name.
+            toolName:
+              type: string
+              description: The tool tried out by the lead.


### PR DESCRIPTION
The PR is about adding a new activity type to Lead Router service API that should be used a lead tried out a free tool.
The firstName and lastName pair are still to be agreed with Shamil. I'd like to keep the naming consistent with other activities.
[Link to the Jira item](https://blackbirdsoftware.atlassian.net/browse/IBA-119).