### PR TITLE
[IBA-117] Extend the BalanceCharge model and create an end-point for BalanceFunds.

### DIFF
--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2583,7 +2583,7 @@ components:
         id:
           $ref: "#/components/schemas/Id"
         resourceAmount:
-          type: number
+          type: integer
           format: int64
           description: The consumed amount of a resource associated with the charge.
         feature:

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -1074,7 +1074,9 @@ paths:
       tags:
         - Balances
       summary: Retrieve balance funds
-      description: Use this endpoint to get information about the balance funds of the tenant.
+      description: |
+        Use this endpoint to get information about the balance funds of the tenant.
+        This operation supports paging, sorting, and filtering. Provide an ID in the path.
       operationId: getBalanceFunds
       parameters:
         - $ref: "#/components/parameters/ResourceId"
@@ -1096,7 +1098,8 @@ paths:
           in: query
           required: false
           description: |
-            The true/false parameter that filters funds included or not included in a plan. If the paramer is missing, then it returns all funds.
+            The true/false parameter that identifies if the fund is included in a plan.
+            If the parameter isn't specified, the method returns all funds.
           schema:
             type: boolean
         - $ref: "#/components/parameters/QueryPageNumber"
@@ -1104,7 +1107,7 @@ paths:
         - $ref: "#/components/parameters/QuerySort"
       responses:
         200:
-          description: Returns the Balance Charges object.
+          description: The balance funds have been retrieved. Returns balance funds.
           content:
             application/json:
               schema:
@@ -2593,7 +2596,7 @@ components:
         netAmount:
           type: number
           format: double
-          description: The net amount of the charge.
+          description: The amount without taxes.
         taxAmount:
           type: number
           format: double

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2827,6 +2827,7 @@ components:
     FeaturePriceModel:
       type: string
       enum:
+        - PREPAID
         - STANDARD
         - METERED
       description: The FeaturePriceModel object defines what price model the feature has.

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -2584,7 +2584,7 @@ components:
           $ref: "#/components/schemas/Id"
         resourceAmount:
           type: number
-          format: double
+          format: int64
           description: The consumed amount of a resource associated with the charge.
         feature:
           $ref: "#/components/schemas/Feature"

--- a/hub/hub-api.yaml
+++ b/hub/hub-api.yaml
@@ -1069,6 +1069,53 @@ paths:
               schema:
                 $ref: "#/components/schemas/ResponseError"
 
+  /tenants/{id}/balance/funds:
+    get:
+      tags:
+        - Balances
+      summary: Retrieve balance funds
+      description: Use this endpoint to get information about the balance funds of the tenant.
+      operationId: getBalanceFunds
+      parameters:
+        - $ref: "#/components/parameters/ResourceId"
+        - name: from
+          in: query
+          required: false
+          description: The start date.
+          schema:
+            type: integer
+            format: int64
+        - name: to
+          in: query
+          required: false
+          description: The finish date.
+          schema:
+            type: integer
+            format: int64
+        - name: isIncluded
+          in: query
+          required: false
+          description: |
+            The true/false parameter that filters funds included or not included in a plan. If the paramer is missing, then it returns all funds.
+          schema:
+            type: boolean
+        - $ref: "#/components/parameters/QueryPageNumber"
+        - $ref: "#/components/parameters/QueryPageSize"
+        - $ref: "#/components/parameters/QuerySort"
+      responses:
+        200:
+          description: Returns the Balance Charges object.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BalanceFunds"
+        default:
+          description: Bad request, security violation, or internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseError"
+
   /tenants/companyInfo:
     put:
       tags:
@@ -2527,12 +2574,22 @@ components:
       description: The object contains the tenant's balance charge information.
       required:
         - id
-        - netAmount
+        - resourceAmount
+        - feature
+        - price
         - createAt
         - updatedAt
       properties:
         id:
           $ref: "#/components/schemas/Id"
+        resourceAmount:
+          type: number
+          format: double
+          description: The consumed amount of a resource associated with the charge.
+        feature:
+          $ref: "#/components/schemas/Feature"
+        price:
+          $ref: "#/components/schemas/Price"
         netAmount:
           type: number
           format: double
@@ -2566,6 +2623,53 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/BalanceCharge"
+        paging:
+          $ref: "#/components/schemas/PageAndSort"
+
+    BalanceFund:
+      type: object
+      description: The object contains the tenant's balance fund information.
+      required:
+        - id
+        - initialAmount
+        - currentAmount
+        - isIncluded
+        - createAt
+        - updatedAt
+      properties:
+        id:
+          $ref: "#/components/schemas/Id"
+        initialAmount:
+          type: number
+          format: double
+          description: The initial amount of the fund.
+        currentAmount:
+          type: number
+          format: double
+          description: The current amount of the fund.
+        feature:
+          $ref: "#/components/schemas/Feature"
+          description: The feature of the prepaid fund.
+        isIncluded:
+          type: boolean
+          description: The true/false parameter that marks if it's a prepaid fund included in a plan.
+        createdAt:
+          type: integer
+          description: The date the fund was created.
+          format: int64
+        updatedAt:
+          type: integer
+          description: The date the fund was modified.
+          format: int64
+
+    BalanceFunds:
+      type: object
+      description: The list of available funds.
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/BalanceFund"
         paging:
           $ref: "#/components/schemas/PageAndSort"
 
@@ -2706,13 +2810,19 @@ components:
     Feature:
       type: object
       description: The object mapping a feature name to a corresponding Inperium product.
+      required:
+        - anchor
+        - product
       properties:
         anchor:
           type: string
-          description: The feature name, e.g., 'CONTACT_IMPORT' or 'PIPELINE_MANAGEMENT'.
+          description: The feature anchor, e.g., 'CONTACT_IMPORT' or 'PIPELINE_MANAGEMENT'.
         product:
           type: string
           description: The Inperium app.
+        name:
+          type: string
+          description: The localized feature name, e.g., 'Contact Import' or 'Die Pipeline-Verwaltung'.
 
     FeaturePriceModel:
       type: string


### PR DESCRIPTION
The PR adds more information to the BalanceCharge model to make it more informative for the users. New attributes show not the only amount of money but also what feature and amount of resource are associated with the charge.
Additionally, the PR adds a new end-point allowing to get balance funds. It starts to be important to show that information to users because, after implementing [IBA-117](https://blackbirdsoftware.atlassian.net/browse/IBA-117),  we will have 2 types of funds:

1. The standard ones. Hub creates them automatically basing on the balance configuration. They imply an amount of money the tenant can spend on any metered add-on.
2. The prepaid funds. They imply an amount of resource/feature the tenant can spend. For example, amount of minutes of domestic calls. They can be 
  a. Included in plans. Such funds are created automatically when tenants switch to a paid plan.
  b. Add-ons that tenants can buy at any time in addition to the included funds.