### PR TITLE
Fixed call forwarding API for Talk

### DIFF
--- a/talk/talk-api.yaml
+++ b/talk/talk-api.yaml
@@ -3331,7 +3331,7 @@ components:
           $ref: '#/components/schemas/AudioFile'
         defaultPhoneNumber:
           $ref: '#/components/schemas/PhoneNumber'
-        defaultForwarding:
+        callForwarding:
           $ref: '#/components/schemas/CallForwarding'
     User:
       type: object
@@ -3639,10 +3639,13 @@ components:
     CallForwarding:
       type: object
       required:
+        - enabled
         - phoneNumber
         - twentyFourSeven
         - businessHours
       properties:
+        enabled:
+          type: boolean
         phoneNumber:
           type: string
         timezone:

--- a/talk/talk-api.yaml
+++ b/talk/talk-api.yaml
@@ -2605,6 +2605,8 @@ components:
           $ref: '#/components/schemas/Address'
         callForwarding:
           $ref: '#/components/schemas/CallForwarding'
+        useDefaultForwarding:
+          type: boolean
     PhoneNumberAssignmentType:
       type: string
       description: Assignment type of the phone number (to whom is it assigned)
@@ -3320,7 +3322,7 @@ components:
           $ref: '#/components/schemas/Id'
         defaultPhoneNumberId:
           $ref: '#/components/schemas/Id'
-        callForwarding:
+        defaultForwarding:
           $ref: '#/components/schemas/CallForwarding'
     UserSettings:
       type: object
@@ -3329,7 +3331,7 @@ components:
           $ref: '#/components/schemas/AudioFile'
         defaultPhoneNumber:
           $ref: '#/components/schemas/PhoneNumber'
-        callForwarding:
+        defaultForwarding:
           $ref: '#/components/schemas/CallForwarding'
     User:
       type: object
@@ -3637,13 +3639,10 @@ components:
     CallForwarding:
       type: object
       required:
-        - enabled
         - phoneNumber
         - twentyFourSeven
         - businessHours
       properties:
-        enabled:
-          type: boolean
         phoneNumber:
           type: string
         timezone:

--- a/talk/talk-api.yaml
+++ b/talk/talk-api.yaml
@@ -3335,7 +3335,7 @@ components:
           $ref: '#/components/schemas/AudioFile'
         defaultPhoneNumber:
           $ref: '#/components/schemas/PhoneNumber'
-        callForwarding:
+        defaultCallForwarding:
           $ref: '#/components/schemas/CallForwarding'
     User:
       type: object

--- a/talk/talk-api.yaml
+++ b/talk/talk-api.yaml
@@ -2571,7 +2571,7 @@ components:
         - timeout
         - countryCode
         - whatsappEnabled
-        - useDefaultForwarding
+        - useDefaultCallForwarding
       properties:
         id:
           $ref: '#/components/schemas/Id'
@@ -2606,7 +2606,7 @@ components:
           $ref: '#/components/schemas/Address'
         callForwarding:
           $ref: '#/components/schemas/CallForwarding'
-        useDefaultForwarding:
+        useDefaultCallForwarding:
           type: boolean
     PhoneNumberAssignmentType:
       type: string
@@ -2665,7 +2665,7 @@ components:
           type: boolean
         callForwarding:
           $ref: '#/components/schemas/CallForwarding'
-        useDefaultForwarding:
+        useDefaultCallForwarding:
           type: boolean
           default: false
     IVRMenuRequest:

--- a/talk/talk-api.yaml
+++ b/talk/talk-api.yaml
@@ -2664,6 +2664,8 @@ components:
           type: boolean
         callForwarding:
           $ref: '#/components/schemas/CallForwarding'
+        useDefaultForwarding:
+          type: boolean
     IVRMenuRequest:
       required:
         - audioPromptId

--- a/talk/talk-api.yaml
+++ b/talk/talk-api.yaml
@@ -2571,6 +2571,7 @@ components:
         - timeout
         - countryCode
         - whatsappEnabled
+        - useDefaultForwarding
       properties:
         id:
           $ref: '#/components/schemas/Id'
@@ -2666,6 +2667,7 @@ components:
           $ref: '#/components/schemas/CallForwarding'
         useDefaultForwarding:
           type: boolean
+          default: false
     IVRMenuRequest:
       required:
         - audioPromptId

--- a/talk/talk-api.yaml
+++ b/talk/talk-api.yaml
@@ -3326,7 +3326,7 @@ components:
           $ref: '#/components/schemas/Id'
         defaultPhoneNumberId:
           $ref: '#/components/schemas/Id'
-        defaultForwarding:
+        defaultCallForwarding:
           $ref: '#/components/schemas/CallForwarding'
     UserSettings:
       type: object


### PR DESCRIPTION
- The `defaultForwarding` is a user setting (without on/off switch).
- The `callForwarding` is an optional parameter for phone settings.
- The `useDefaultForwarding` is a boolean parameter for phone settings. While enabled it overrides the phone `call forwarding` setting.